### PR TITLE
Support for protocol v19 & remove need for Conan

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,21 +9,26 @@ set(CMAKE_C_STANDARD_REQUIRED ON)
 
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
 
-# Set up Conan
-include(${CMAKE_SOURCE_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
 
 # Find Boost
-set(CMAKE_MODULE_PATH ${CONAN_CMAKE_MODULE_PATH} ${CMAKE_MODULE_PATH})
-find_package(Boost 1.66)
+find_package(Boost 1.66 REQUIRED COMPONENTS system filesystem program_options)
 
 # Do not build Kaitai runtime with iconv
 add_definitions(-DKS_STR_ENCODING_NONE)
 
 # Include directories
 include_directories (${CMAKE_SOURCE_DIR}/src)
+include_directories("/usr/local/include/pcapplusplus")
 #include_directories (${Boost_INCLUDE_DIRS})
+
+#Link directories
+link_directories("/usr/local/lib")
+
+# Assuming other libraries are installed and findable
+find_package(JSONForModernCPP REQUIRED)
+find_package(Threads REQUIRED)
 
 # Regenerate parser. The nanocurrency/protocol repository must be
 # added as a submodule when this flag is active.
@@ -45,17 +50,11 @@ if (NANOCAP_GENERATE_PARSER)
 endif ()
 
 # Blake2
-if(SSE STREQUAL "None")
-	file(GLOB_RECURSE blake2_sources
-		"src/blake2/ref/blake2*.h"
-		"src/blake2/ref/blake2*.c")
-	include_directories (src/blake2/ref)
-else()
-	file(GLOB_RECURSE blake2_sources
-		"src/blake2/sse/blake2*.h"
-		"src/blake2/sse/blake2*.c")
-	include_directories (src/blake2/sse)
-endif()
+file(GLOB_RECURSE blake2_sources
+	"src/blake2/ref/blake2*.h"
+	"src/blake2/ref/blake2*.c")
+include_directories (src/blake2/ref)
+
 add_library(blake2b ${blake2_sources})
 
 include_directories (src/sqlite)
@@ -76,7 +75,8 @@ add_executable(nanocap
 	src/util/ctpl_stl.h src/util/termcolor.hpp
 	)
 
-target_link_libraries(nanocap blake2b sqlite sqlitecpp CONAN_PKG::boost_system CONAN_PKG::boost_filesystem CONAN_PKG::boost_program_options CONAN_PKG::boost_asio CONAN_PKG::boost_multiprecision CONAN_PKG::boost_circular_buffer CONAN_PKG::jsonformoderncpp CONAN_PKG::pcapplusplus ${CMAKE_DL_LIBS})
+target_link_libraries(nanocap blake2b sqlite sqlitecpp Boost::system Boost::filesystem Boost::program_options JSONForModernCPP /usr/local/lib/libPacket++.a /usr/local/lib/libPcap++.a /usr/local/lib/libCommon++.a pcap ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS})
+
 
 if (APPLE)
 	target_link_libraries(nanocap "-framework CoreFoundation")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,10 +50,18 @@ if (NANOCAP_GENERATE_PARSER)
 endif ()
 
 # Blake2
-file(GLOB_RECURSE blake2_sources
-	"src/blake2/ref/blake2*.h"
-	"src/blake2/ref/blake2*.c")
-include_directories (src/blake2/ref)
+# Check for SSE instruction set
+if(SSE STREQUAL "None" OR CMAKE_SYSTEM_PROCESSOR MATCHES "arm")
+    file(GLOB_RECURSE blake2_sources
+        "src/blake2/ref/blake2*.h"
+        "src/blake2/ref/blake2*.c")
+    include_directories(src/blake2/ref)
+else()
+    file(GLOB_RECURSE blake2_sources
+        "src/blake2/sse/blake2*.h"
+        "src/blake2/sse/blake2*.c")
+    include_directories(src/blake2/sse)
+endif()
 
 add_library(blake2b ${blake2_sources})
 

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,35 +1,53 @@
-FROM ubuntu:18.04
-MAINTAINER cryptocode <cryptocode@zolo.io>
+FROM ubuntu:20.04
 LABEL Description="Protocol analyzer for the Nano network"
 EXPOSE 8077
 
+ENV DEBIAN_FRONTEND=noninteractive
+RUN ln -fs /usr/share/zoneinfo/UTC /etc/localtime
+
 RUN apt-get update && apt-get install -y \
-	apt-transport-https
-RUN apt-get update && apt-get install -y \
-    software-properties-common
-RUN add-apt-repository universe
-RUN apt-get update && apt-get install -y \
-	curl \
-	wget \
-    git \
+    apt-transport-https \
+    software-properties-common \
+    curl \
+    wget \
     cmake \
     python3.4 \
-    python3-pip
+    python3-pip \
+    git \  
+    g++    
 
+# Add the required libraries. 
+# Please note that the package names may vary between Ubuntu versions.
+RUN apt-get update && apt-get install -y \
+    libboost-all-dev \
+    libjsoncpp-dev \
+    libpcap-dev
+
+# Create a directory for the project
 RUN mkdir /nanocap
-RUN cd /nanocap
-RUN cmake --version
-
-RUN wget https://bootstrap.pypa.io/get-pip.py
-RUN python3 get-pip.py 'pip==18.1'
-RUN pip install conan --ignore-installed urllib3
-
 WORKDIR /nanocap
-RUN git clone https://github.com/cryptocode/nanocap.git .
 
-RUN conan remote add bincrafters https://api.bintray.com/conan/bincrafters/public-conan
-RUN conan install . --build=missing -s compiler.libcxx=libstdc++11
+# Clone and install PcapPlusPlus
+RUN git clone https://github.com/seladb/PcapPlusPlus.git
+WORKDIR PcapPlusPlus
+RUN git checkout 8f87300e4f308bfaa62b76f6d43df3e662c12b9e
+RUN ./configure-linux.sh --default
+RUN make all
+RUN make install
+WORKDIR /nanocap
+
+# Copy the local project directory into the Docker image
+COPY . /nanocap
+
+# Download json.hpp from JSONForModernCPP GitHub repository
+RUN mkdir -p /nanocap/external/JSONForModernCPP/include/nlohmann
+RUN curl -Lo /nanocap/external/JSONForModernCPP/include/nlohmann/json.hpp https://github.com/nlohmann/json/releases/download/v3.9.1/json.hpp
+
+# Modify CMakeLists.txt to use the downloaded json.hpp file
+RUN sed -i 's|include_directories (${Boost_INCLUDE_DIRS})|include_directories (${Boost_INCLUDE_DIRS} /nanocap/external/JSONForModernCPP/include)|' /nanocap/CMakeLists.txt
+
+RUN dpkg-reconfigure --frontend noninteractive tzdata
 RUN cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -G "Unix Makefiles" .
 RUN make
 
-CMD bin/nanocap --help
+CMD ./nanocap --help

--- a/cmake/FindJSONForModernCPP.cmake
+++ b/cmake/FindJSONForModernCPP.cmake
@@ -1,0 +1,19 @@
+# - Try to find json.hpp
+# Once done, this will define
+# 
+#  JSONForModernCPP_FOUND - system has json.hpp
+#  JSONForModernCPP_INCLUDE_DIRS - the json.hpp include directories
+
+find_path(JSONForModernCPP_INCLUDE_DIRS NAMES nlohmann/json.hpp
+    PATHS /nanocap/external/JSONForModernCPP/include)
+
+add_library(JSONForModernCPP INTERFACE IMPORTED)
+set_target_properties(JSONForModernCPP PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${JSONForModernCPP_INCLUDE_DIRS}")
+
+include(FindPackageHandleStandardArgs)
+# handle the QUIETLY and REQUIRED arguments and set JSONForModernCPP_FOUND to TRUE
+# if all listed variables are TRUE
+find_package_handle_standard_args(JSONForModernCPP DEFAULT_MSG JSONForModernCPP_INCLUDE_DIRS)
+
+mark_as_advanced(JSONForModernCPP_INCLUDE_DIRS)

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -736,20 +736,8 @@ std::error_code nanocap::db::put(nano::protocol::nano_t::msg_confirm_ack_t& msg,
 	bind_header_fields(stmt_packet.get(), msg, packet_id);
 	bind_packet_fields(stmt_packet.get(), info);
 	
-	// Regular vote
-	if (msg.block())
-	{
-		int64_t block_content_id = next_id.fetch_add(1);
-		std::string content_table;
-		put_block(msg.block(), block_content_id, packet_id, content_table);
-		
-		stmt_vote->bind(":content_id", block_content_id);
-		stmt_vote->bind(":content_table", content_table);
-		stmt_vote->bind(":vote_count", 1);
-		stmt_vote->bind(":vbh", 0);
-	}
 	// Vote-by-hash
-	else if (msg.votebyhash() && msg.votebyhash()->hashes() && !msg.votebyhash()->hashes()->empty())
+	if (msg.votebyhash() && msg.votebyhash()->hashes() && !msg.votebyhash()->hashes()->empty())
 	{
 		stmt_vote->bind(":vbh", 1);
 		std::ostringstream hashes;
@@ -779,7 +767,7 @@ std::error_code nanocap::db::put(nano::protocol::nano_t::msg_confirm_ack_t& msg,
 	{
 		stmt_vote->bind(":account", pub_to_account(msg.common()->account()));
 		stmt_vote->bind(":signature", to_hex(msg.common()->signature()));
-		stmt_vote->bind(":sequence", static_cast<int64_t>(msg.common()->sequence()));
+		stmt_vote->bind(":sequence", static_cast<int64_t>(msg.common()->timestamp_and_vote_duration()));
 	}
 	else
 	{

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -880,6 +880,45 @@ std::error_code nanocap::db::put(nano::protocol::nano_t::msg_publish_t& msg, nan
 	return ec;
 }
 
+std::error_code nanocap::db::put(nano::protocol::nano_t::msg_asc_pull_ack_t& msg, nanocap::nano_packet& info)
+{	
+    std::error_code ec;
+	int64_t packet_id = next_id.fetch_add(1);
+    std::lock_guard<std::mutex> guard (db_mutex);    
+    bind_header_fields(stmt_packet.get(), msg, packet_id);
+    bind_packet_fields(stmt_packet.get(), info);
+	stmt_packet->bind(":content_id", packet_id);
+	
+	auto rows = stmt_packet->exec();
+	assert (rows == 1);
+	// Prepare for next use
+	stmt_packet->reset();
+
+    // Continue as per your existing structure
+    return ec;
+}
+
+std::error_code nanocap::db::put(nano::protocol::nano_t::msg_asc_pull_req_t& msg, nanocap::nano_packet& info)
+{
+    std::error_code ec;
+	int64_t packet_id = next_id.fetch_add(1);
+    std::lock_guard<std::mutex> guard (db_mutex);    
+    bind_header_fields(stmt_packet.get(), msg, packet_id);
+    bind_packet_fields(stmt_packet.get(), info);
+	stmt_packet->bind(":content_id", packet_id);
+	
+	auto rows = stmt_packet->exec();
+	assert (rows == 1);
+	// Prepare for next use
+	stmt_packet->reset();
+
+    // Continue as per your existing structure
+    return ec;
+}
+
+
+
+
 // Must be called with db_mutex locked
 std::error_code nanocap::db::put_block(nano::protocol::nano_t::block_selector_t* block_selector,
 									   int64_t id, int64_t packet_id, std::string& content_table)

--- a/src/db.hpp
+++ b/src/db.hpp
@@ -42,6 +42,8 @@ namespace nanocap
 		std::error_code put(nano::protocol::nano_t::msg_bulk_pull_account_t& msg, nano_packet& info);
 		std::error_code put(nano::protocol::nano_t::bulk_pull_account_response_t::frontier_balance_entry_t& entry, nano_packet& info);
 		std::error_code put(nano::protocol::nano_t::bulk_pull_account_response_t::bulk_pull_account_entry_t& entry, nano_packet& info);
+		std::error_code put(nano::protocol::nano_t::msg_asc_pull_ack_t& msg, nano_packet& info);		
+		std::error_code put(nano::protocol::nano_t::msg_asc_pull_req_t& msg, nano_packet& info);
 
 		/** Arbitrary query returned as json, including (real and synthentic) column names */
 		json query(std::string query);
@@ -161,6 +163,7 @@ namespace nanocap
 		std::unique_ptr<SQLite::Statement> stmt_bulk_pull_account_request;
 		std::unique_ptr<SQLite::Statement> stmt_bulk_pull_account_response;
 		std::unique_ptr<SQLite::Statement> stmt_bulk_pull_account_response_entry;
+		std::unique_ptr<SQLite::Statement> stmt_msg_asc_pull;
 
 		/** Next ID for sqlite insert (note that sqlite3 only supports signed integers */
 		std::atomic<std::int64_t> next_id {0};

--- a/src/kaitai/kaitaistream.cpp
+++ b/src/kaitai/kaitaistream.cpp
@@ -1,5 +1,8 @@
-#include <kaitai/kaitaistream.h>
+#include "kaitaistream.h"
 
+#define KS_STR_ENCODING_NONE
+
+// macOS
 #if defined(__APPLE__)
 #include <machine/endian.h>
 #include <libkern/OSByteOrder.h>
@@ -9,7 +12,8 @@
 #define __BYTE_ORDER    BYTE_ORDER
 #define __BIG_ENDIAN    BIG_ENDIAN
 #define __LITTLE_ENDIAN LITTLE_ENDIAN
-#elif defined(_MSC_VER) // !__APPLE__
+// Windows with MS or MinGW compilers
+#elif defined(_MSC_VER) || defined(__MINGW32__)
 #include <stdlib.h>
 #define __LITTLE_ENDIAN     1234
 #define __BIG_ENDIAN        4321
@@ -17,7 +21,19 @@
 #define bswap_16(x) _byteswap_ushort(x)
 #define bswap_32(x) _byteswap_ulong(x)
 #define bswap_64(x) _byteswap_uint64(x)
-#else // !__APPLE__ or !_MSC_VER
+// BSD
+#elif defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__)
+#include <sys/endian.h>
+#define bswap_16(x) bswap16(x)
+#define bswap_32(x) bswap32(x)
+#define bswap_64(x) bswap64(x)
+#elif defined(__OpenBSD__)
+#include <endian.h>
+#define bswap_16(x) swap16(x)
+#define bswap_32(x) swap32(x)
+#define bswap_64(x) swap64(x)
+// Everything else
+#else
 #include <endian.h>
 #include <byteswap.h>
 #endif
@@ -26,12 +42,12 @@
 #include <vector>
 #include <stdexcept>
 
-kaitai::kstream::kstream(std::istream* io) {
+kaitai::kstream::kstream(std::istream *io) {
     m_io = io;
     init();
 }
 
-kaitai::kstream::kstream(std::string& data): m_io_str(data) {
+kaitai::kstream::kstream(const std::string &data) : m_io_str(data) {
     m_io = &m_io_str;
     init();
 }
@@ -58,10 +74,11 @@ void kaitai::kstream::exceptions_enable() const {
 // ========================================================================
 
 bool kaitai::kstream::is_eof() const {
+    if (m_bits_left > 0) {
+        return false;
+    }
     char t;
-    m_io->exceptions(
-        std::istream::badbit
-    );
+    m_io->exceptions(std::istream::badbit);
     m_io->get(t);
     if (m_io->eof()) {
         m_io->clear();
@@ -246,13 +263,14 @@ uint64_t kaitai::kstream::read_u8le() {
 // Big-endian
 // ........................................................................
 
+/*
 float kaitai::kstream::read_f4be() {
     uint32_t t;
     m_io->read(reinterpret_cast<char *>(&t), 4);
 #if __BYTE_ORDER == __LITTLE_ENDIAN
     t = bswap_32(t);
 #endif
-    return reinterpret_cast<float&>(t);
+    return reinterpret_cast<float &>(t);
 }
 
 double kaitai::kstream::read_f8be() {
@@ -261,7 +279,7 @@ double kaitai::kstream::read_f8be() {
 #if __BYTE_ORDER == __LITTLE_ENDIAN
     t = bswap_64(t);
 #endif
-    return reinterpret_cast<double&>(t);
+    return reinterpret_cast<double &>(t);
 }
 
 // ........................................................................
@@ -274,7 +292,7 @@ float kaitai::kstream::read_f4le() {
 #if __BYTE_ORDER == __BIG_ENDIAN
     t = bswap_32(t);
 #endif
-    return reinterpret_cast<float&>(t);
+    return reinterpret_cast<float &>(t);
 }
 
 double kaitai::kstream::read_f8le() {
@@ -283,8 +301,9 @@ double kaitai::kstream::read_f8le() {
 #if __BYTE_ORDER == __BIG_ENDIAN
     t = bswap_64(t);
 #endif
-    return reinterpret_cast<double&>(t);
+    return reinterpret_cast<double &>(t);
 }
+*/
 
 // ========================================================================
 // Unaligned bit values
@@ -295,46 +314,81 @@ void kaitai::kstream::align_to_byte() {
     m_bits = 0;
 }
 
-uint64_t kaitai::kstream::read_bits_int(int n) {
+uint64_t kaitai::kstream::read_bits_int_be(int n) {
+    uint64_t res = 0;
+
     int bits_needed = n - m_bits_left;
+    m_bits_left = -bits_needed & 7; // `-bits_needed mod 8`
+
     if (bits_needed > 0) {
         // 1 bit  => 1 byte
         // 8 bits => 1 byte
         // 9 bits => 2 bytes
-        int bytes_needed = ((bits_needed - 1) / 8) + 1;
+        int bytes_needed = ((bits_needed - 1) / 8) + 1; // `ceil(bits_needed / 8)`
         if (bytes_needed > 8)
-            throw std::runtime_error("read_bits_int: more than 8 bytes requested");
-        char buf[8];
-        m_io->read(buf, bytes_needed);
+            throw std::runtime_error("read_bits_int_be: more than 8 bytes requested");
+        uint8_t buf[8];
+        m_io->read(reinterpret_cast<char *>(buf), bytes_needed);
         for (int i = 0; i < bytes_needed; i++) {
-            uint8_t b = buf[i];
-            m_bits <<= 8;
-            m_bits |= b;
-            m_bits_left += 8;
+            res = res << 8 | buf[i];
         }
+
+        uint64_t new_bits = res;
+        res = res >> m_bits_left | (bits_needed < 64 ? m_bits << bits_needed : 0); // avoid undefined behavior of `x << 64`
+        m_bits = new_bits; // will be masked at the end of the function
+    } else {
+        res = m_bits >> -bits_needed; // shift unneeded bits out
     }
 
-    // raw mask with required number of 1s, starting from lowest bit
-    uint64_t mask = get_mask_ones(n);
-    // shift mask to align with highest bits available in @bits
-    int shift_bits = m_bits_left - n;
-    mask <<= shift_bits;
-    // derive reading result
-    uint64_t res = (m_bits & mask) >> shift_bits;
-    // clear top bits that we've just read => AND with 1s
-    m_bits_left -= n;
-    mask = get_mask_ones(m_bits_left);
+    uint64_t mask = (UINT64_C(1) << m_bits_left) - 1; // `m_bits_left` is in range 0..7, so `(1 << 64)` does not have to be considered
     m_bits &= mask;
 
     return res;
 }
 
-uint64_t kaitai::kstream::get_mask_ones(int n) {
-    if (n == 64) {
-        return 0xFFFFFFFFFFFFFFFF;
+// Deprecated, use read_bits_int_be() instead.
+uint64_t kaitai::kstream::read_bits_int(int n) {
+    return read_bits_int_be(n);
+}
+
+uint64_t kaitai::kstream::read_bits_int_le(int n) {
+    uint64_t res = 0;
+    int bits_needed = n - m_bits_left;
+
+    if (bits_needed > 0) {
+        // 1 bit  => 1 byte
+        // 8 bits => 1 byte
+        // 9 bits => 2 bytes
+        int bytes_needed = ((bits_needed - 1) / 8) + 1; // `ceil(bits_needed / 8)`
+        if (bytes_needed > 8)
+            throw std::runtime_error("read_bits_int_le: more than 8 bytes requested");
+        uint8_t buf[8];
+        m_io->read(reinterpret_cast<char *>(buf), bytes_needed);
+        for (int i = 0; i < bytes_needed; i++) {
+            res |= static_cast<uint64_t>(buf[i]) << (i * 8);
+        }
+
+        // NB: for bit shift operators in C++, "if the value of the right operand is
+        // negative or is greater or equal to the number of bits in the promoted left
+        // operand, the behavior is undefined." (see
+        // https://en.cppreference.com/w/cpp/language/operator_arithmetic#Bitwise_shift_operators)
+        // So we define our desired behavior here.
+        uint64_t new_bits = bits_needed < 64 ? res >> bits_needed : 0;
+        res = res << m_bits_left | m_bits;
+        m_bits = new_bits;
     } else {
-        return ((uint64_t) 1 << n) - 1;
+        res = m_bits;
+        m_bits >>= n;
     }
+
+    m_bits_left = -bits_needed & 7; // `-bits_needed mod 8`
+
+    if (n < 64) {
+        uint64_t mask = (UINT64_C(1) << n) - 1;
+        res &= mask;
+    }
+    // if `n == 64`, do nothing
+    return res;
 }
 
 // ========================================================================
@@ -350,7 +404,7 @@ std::string kaitai::kstream::read_bytes(std::streamsize len) {
         throw std::runtime_error("read_bytes: requested a negative amount");
     }
 
-    if (len > 0 ) {
+    if (len > 0) {
         m_io->read(&result[0], len);
     }
 
@@ -396,7 +450,9 @@ std::string kaitai::kstream::ensure_fixed_contents(std::string expected) {
     std::string actual = read_bytes(expected.length());
 
     if (actual != expected) {
-        // NOTE: I think printing it outright is not best idea, it could contain non-ascii charactes like backspace and beeps and whatnot. It would be better to print hexlified version, and also to redirect it to stderr.
+        // NOTE: I think printing it outright is not best idea, it could contain non-ASCII characters
+        // like backspace and beeps and whatnot. It would be better to print hexlified version, and
+        // also to redirect it to stderr.
         throw std::runtime_error("ensure_fixed_contents: actual data does not match expected data");
     }
 
@@ -473,7 +529,7 @@ std::string kaitai::kstream::process_rotate_left(std::string data, int amount) {
 std::string kaitai::kstream::process_zlib(std::string data) {
     int ret;
 
-    unsigned char *src_ptr = reinterpret_cast<unsigned char*>(&data[0]);
+    unsigned char *src_ptr = reinterpret_cast<unsigned char *>(&data[0]);
     std::stringstream dst_strm;
 
     z_stream strm;
@@ -493,16 +549,16 @@ std::string kaitai::kstream::process_zlib(std::string data) {
 
     // get the decompressed bytes blockwise using repeated calls to inflate
     do {
-        strm.next_out = reinterpret_cast<Bytef*>(outbuffer);
+        strm.next_out = reinterpret_cast<Bytef *>(outbuffer);
         strm.avail_out = sizeof(outbuffer);
 
         ret = inflate(&strm, 0);
 
         if (outstring.size() < strm.total_out)
-            outstring.append(reinterpret_cast<char*>(outbuffer), strm.total_out - outstring.size());
+            outstring.append(reinterpret_cast<char *>(outbuffer), strm.total_out - outstring.size());
     } while (ret == Z_OK);
 
-    if (ret != Z_STREAM_END) {          // an error occurred that was not EOF
+    if (ret != Z_STREAM_END) { // an error occurred that was not EOF
         std::ostringstream exc_msg;
         exc_msg << "process_zlib: error #" << ret << "): " << strm.msg;
         throw std::runtime_error(exc_msg.str());
@@ -528,27 +584,51 @@ int kaitai::kstream::mod(int a, int b) {
     return r;
 }
 
-#include <stdio.h>
-std::string kaitai::kstream::to_string(int val) {
-    // if int is 32 bits, "-2147483648" is longest string representation
-    //   => 11 chars + zero => 12 chars
-    // if int is 64 bits, "-9223372036854775808" is longest
-    //   => 20 chars + zero => 21 chars
-    char buf[25];
-    int got_len = snprintf(buf, sizeof(buf), "%d", val);
-
-    // should never happen, but check nonetheless
-    if (got_len > sizeof(buf))
-        throw std::invalid_argument("to_string: integer is longer than string buffer");
-
-    return std::string(buf);
+#include <algorithm>
+void kaitai::kstream::unsigned_to_decimal(uint64_t number, char *buffer) {
+    // Implementation from https://ideone.com/nrQfA8 by Alf P. Steinbach
+    // (see https://www.zverovich.net/2013/09/07/integer-to-string-conversion-in-cplusplus.html#comment-1033931478)
+    if (number == 0) {
+        *buffer++ = '0';
+    } else {
+        char *p_first = buffer;
+        while (number != 0) {
+            *buffer++ = static_cast<char>('0' + number % 10);
+            number /= 10;
+        }
+        std::reverse(p_first, buffer);
+    }
+    *buffer = '\0';
 }
 
-#include <algorithm>
 std::string kaitai::kstream::reverse(std::string val) {
     std::reverse(val.begin(), val.end());
 
     return val;
+}
+
+uint8_t kaitai::kstream::byte_array_min(const std::string val) {
+    uint8_t min = 0xff; // UINT8_MAX
+    std::string::const_iterator end = val.end();
+    for (std::string::const_iterator it = val.begin(); it != end; ++it) {
+        uint8_t cur = static_cast<uint8_t>(*it);
+        if (cur < min) {
+            min = cur;
+        }
+    }
+    return min;
+}
+
+uint8_t kaitai::kstream::byte_array_max(const std::string val) {
+    uint8_t max = 0; // UINT8_MIN
+    std::string::const_iterator end = val.end();
+    for (std::string::const_iterator it = val.begin(); it != end; ++it) {
+        uint8_t cur = static_cast<uint8_t>(*it);
+        if (cur > max) {
+            max = cur;
+        }
+    }
+    return max;
 }
 
 // ========================================================================
@@ -568,7 +648,7 @@ std::string kaitai::kstream::reverse(std::string val) {
 std::string kaitai::kstream::bytes_to_str(std::string src, std::string src_enc) {
     iconv_t cd = iconv_open(KS_STR_DEFAULT_ENCODING, src_enc.c_str());
 
-    if (cd == (iconv_t) -1) {
+    if (cd == (iconv_t)-1) {
         if (errno == EINVAL) {
             throw std::runtime_error("bytes_to_str: invalid encoding pair conversion requested");
         } else {
@@ -590,7 +670,7 @@ std::string kaitai::kstream::bytes_to_str(std::string src, std::string src_enc) 
     while (true) {
         size_t res = iconv(cd, &src_ptr, &src_left, &dst_ptr, &dst_left);
 
-        if (res == (size_t) -1) {
+        if (res == (size_t)-1) {
             if (errno == E2BIG) {
                 // dst buffer is not enough to accomodate whole string
                 // enlarge the buffer and try again
@@ -621,6 +701,7 @@ std::string kaitai::kstream::bytes_to_str(std::string src, std::string src_enc) 
 }
 #elif defined(KS_STR_ENCODING_NONE)
 std::string kaitai::kstream::bytes_to_str(std::string src, std::string src_enc) {
+    (void)src_enc;
     return src;
 }
 #else

--- a/src/kaitai/kaitaistream.h
+++ b/src/kaitai/kaitaistream.h
@@ -2,18 +2,19 @@
 #define KAITAI_STREAM_H
 
 // Kaitai Struct runtime API version: x.y.z = 'xxxyyyzzz' decimal
-#define KAITAI_STRUCT_VERSION 7000L
+#define KAITAI_STRUCT_VERSION 10000L
 
 #include <istream>
 #include <sstream>
 #include <stdint.h>
 #include <sys/types.h>
+#include <limits>
 
 namespace kaitai {
 
 /**
  * Kaitai Stream class (kaitai::kstream) is an implementation of
- * <a href="https://github.com/kaitai-io/kaitai_struct/wiki/Kaitai-Struct-stream-API">Kaitai Struct stream API</a>
+ * <a href="https://doc.kaitai.io/stream_api.html">Kaitai Struct stream API</a>
  * for C++/STL. It's implemented as a wrapper over generic STL std::istream.
  *
  * It provides a wide variety of simple methods to read (parse) binary
@@ -41,7 +42,7 @@ public:
      * buffer.
      * \param data data buffer to use for this Kaitai Stream
      */
-    kstream(std::string& data);
+    kstream(const std::string& data);
 
     void close();
 
@@ -148,7 +149,9 @@ public:
     //@{
 
     void align_to_byte();
+    uint64_t read_bits_int_be(int n);
     uint64_t read_bits_int(int n);
+    uint64_t read_bits_int_le(int n);
 
     //@}
 
@@ -222,7 +225,33 @@ public:
      * Should be used in place of std::to_string() (which is available only
      * since C++11) in older C++ implementations.
      */
-    static std::string to_string(int val);
+    template<typename I>
+// check for C++11 support - https://stackoverflow.com/a/40512515
+#if __cplusplus >= 201103L || (defined(_MSC_VER) && _MSC_VER >= 1900)
+    // https://stackoverflow.com/a/27913885
+    typename std::enable_if<
+            std::is_integral<I>::value &&
+            // check if we don't have something too large like GCC's `__int128_t`
+            std::numeric_limits<I>::max() >= 0 &&
+            std::numeric_limits<I>::max() <= std::numeric_limits<uint64_t>::max(),
+            std::string
+    >::type
+#else
+    std::string
+#endif
+    static to_string(I val) {
+        // in theory, `digits10 + 3` would be enough (minus sign + leading digit
+        // + null terminator), but let's add a little more to be safe
+        char buf[std::numeric_limits<I>::digits10 + 5];
+        if (val < 0) {
+            buf[0] = '-';
+            // get absolute value without undefined behavior (https://stackoverflow.com/a/12231604)
+            unsigned_to_decimal(-static_cast<uint64_t>(val), &buf[1]);
+        } else {
+            unsigned_to_decimal(val, buf);
+        }
+        return std::string(buf);
+    }
 
     /**
      * Reverses given string `val`, so that the first character becomes the
@@ -230,6 +259,22 @@ public:
      * the need of local variables at the caller.
      */
     static std::string reverse(std::string val);
+
+    /**
+     * Finds the minimal byte in a byte array, treating bytes as
+     * unsigned values.
+     * @param val byte array to scan
+     * @return minimal byte in byte array as integer
+     */
+    static uint8_t byte_array_min(const std::string val);
+
+    /**
+     * Finds the maximal byte in a byte array, treating bytes as
+     * unsigned values.
+     * @param val byte array to scan
+     * @return maximal byte in byte array as integer
+     */
+    static uint8_t byte_array_max(const std::string val);
 
 private:
     std::istream* m_io;
@@ -240,7 +285,7 @@ private:
     void init();
     void exceptions_enable() const;
 
-    static uint64_t get_mask_ones(int n);
+    static void unsigned_to_decimal(uint64_t number, char *buffer);
 
     static const int ZLIB_BUF_SIZE = 128 * 1024;
 };

--- a/src/kaitai/kaitaistruct.h
+++ b/src/kaitai/kaitaistruct.h
@@ -1,7 +1,7 @@
 #ifndef KAITAI_STRUCT_H
 #define KAITAI_STRUCT_H
 
-#include <kaitai/kaitaistream.h>
+#include "kaitaistream.h"
 
 namespace kaitai {
 

--- a/src/nano.cpp
+++ b/src/nano.cpp
@@ -1,7 +1,5 @@
 // This is a generated file! Please edit source .ksy file and use kaitai-struct-compiler to rebuild
-
 #include "nano.h"
-
 
 namespace nano {
     namespace protocol {
@@ -11,7 +9,13 @@ namespace nano {
             m__root = this;
             m_header = 0;
             f_const_block_zero = false;
-            _read();
+
+            try {
+                _read();
+            } catch(...) {
+                _clean_up();
+                throw;
+            }
         }
 
         void nano_t::_read() {
@@ -37,6 +41,10 @@ namespace nano {
                 m_body = new msg_keepalive_t(m__io, this, m__root);
                 break;
             }
+            case nano_t::ENUM_MSGTYPE_ASC_PULL_ACK: {
+                m_body = new msg_asc_pull_ack_t(m__io, this, m__root);
+                break;
+            }
             case nano_t::ENUM_MSGTYPE_BULK_PUSH: {
                 m_body = new msg_bulk_push_t(m__io, this, m__root);
                 break;
@@ -53,16 +61,16 @@ namespace nano {
                 m_body = new msg_frontier_req_t(m__io, this, m__root);
                 break;
             }
-            case nano_t::ENUM_MSGTYPE_BULK_PULL_BLOCKS: {
-                m_body = new msg_bulk_pull_blocks_t(m__io, this, m__root);
-                break;
-            }
             case nano_t::ENUM_MSGTYPE_PUBLISH: {
                 m_body = new msg_publish_t(m__io, this, m__root);
                 break;
             }
             case nano_t::ENUM_MSGTYPE_TELEMETRY_REQ: {
                 m_body = new msg_telemetry_req_t(m__io, this, m__root);
+                break;
+            }
+            case nano_t::ENUM_MSGTYPE_ASC_PULL_REQ: {
+                m_body = new msg_asc_pull_req_t(m__io, this, m__root);
                 break;
             }
             default: {
@@ -73,8 +81,16 @@ namespace nano {
         }
 
         nano_t::~nano_t() {
-            delete m_header;
-            delete m_body;
+            _clean_up();
+        }
+
+        void nano_t::_clean_up() {
+            if (m_header) {
+                delete m_header; m_header = 0;
+            }
+            if (m_body) {
+                delete m_body; m_body = 0;
+            }
             if (f_const_block_zero) {
             }
         }
@@ -82,7 +98,13 @@ namespace nano {
         nano_t::block_send_t::block_send_t(kaitai::kstream* p__io, nano_t::block_selector_t* p__parent, nano_t* p__root) : kaitai::kstruct(p__io) {
             m__parent = p__parent;
             m__root = p__root;
-            _read();
+
+            try {
+                _read();
+            } catch(...) {
+                _clean_up();
+                throw;
+            }
         }
 
         void nano_t::block_send_t::_read() {
@@ -94,13 +116,23 @@ namespace nano {
         }
 
         nano_t::block_send_t::~block_send_t() {
+            _clean_up();
+        }
+
+        void nano_t::block_send_t::_clean_up() {
         }
 
         nano_t::confirm_request_by_hash_t::confirm_request_by_hash_t(kaitai::kstream* p__io, nano_t::msg_confirm_req_t* p__parent, nano_t* p__root) : kaitai::kstruct(p__io) {
             m__parent = p__parent;
             m__root = p__root;
             m_pairs = 0;
-            _read();
+
+            try {
+                _read();
+            } catch(...) {
+                _clean_up();
+                throw;
+            }
         }
 
         void nano_t::confirm_request_by_hash_t::_read() {
@@ -121,31 +153,53 @@ namespace nano {
         }
 
         nano_t::confirm_request_by_hash_t::~confirm_request_by_hash_t() {
+            _clean_up();
+        }
+
+        void nano_t::confirm_request_by_hash_t::_clean_up() {
             if (!n_pairs) {
-                for (std::vector<hash_pair_t*>::iterator it = m_pairs->begin(); it != m_pairs->end(); ++it) {
-                    delete *it;
+                if (m_pairs) {
+                    for (std::vector<hash_pair_t*>::iterator it = m_pairs->begin(); it != m_pairs->end(); ++it) {
+                        delete *it;
+                    }
+                    delete m_pairs; m_pairs = 0;
                 }
-                delete m_pairs;
             }
         }
 
         nano_t::msg_telemetry_req_t::msg_telemetry_req_t(kaitai::kstream* p__io, nano_t* p__parent, nano_t* p__root) : kaitai::kstruct(p__io) {
             m__parent = p__parent;
             m__root = p__root;
-            _read();
+
+            try {
+                _read();
+            } catch(...) {
+                _clean_up();
+                throw;
+            }
         }
 
         void nano_t::msg_telemetry_req_t::_read() {
         }
 
         nano_t::msg_telemetry_req_t::~msg_telemetry_req_t() {
+            _clean_up();
+        }
+
+        void nano_t::msg_telemetry_req_t::_clean_up() {
         }
 
         nano_t::block_selector_t::block_selector_t(uint8_t p_arg_block_type, kaitai::kstream* p__io, kaitai::kstruct* p__parent, nano_t* p__root) : kaitai::kstruct(p__io) {
             m__parent = p__parent;
             m__root = p__root;
             m_arg_block_type = p_arg_block_type;
-            _read();
+
+            try {
+                _read();
+            } catch(...) {
+                _clean_up();
+                throw;
+            }
         }
 
         void nano_t::block_selector_t::_read() {
@@ -178,13 +232,25 @@ namespace nano {
         }
 
         nano_t::block_selector_t::~block_selector_t() {
-            delete m_block;
+            _clean_up();
+        }
+
+        void nano_t::block_selector_t::_clean_up() {
+            if (m_block) {
+                delete m_block; m_block = 0;
+            }
         }
 
         nano_t::node_id_query_t::node_id_query_t(kaitai::kstream* p__io, nano_t::msg_node_id_handshake_t* p__parent, nano_t* p__root) : kaitai::kstruct(p__io) {
             m__parent = p__parent;
             m__root = p__root;
-            _read();
+
+            try {
+                _read();
+            } catch(...) {
+                _clean_up();
+                throw;
+            }
         }
 
         void nano_t::node_id_query_t::_read() {
@@ -192,12 +258,22 @@ namespace nano {
         }
 
         nano_t::node_id_query_t::~node_id_query_t() {
+            _clean_up();
+        }
+
+        void nano_t::node_id_query_t::_clean_up() {
         }
 
         nano_t::block_receive_t::block_receive_t(kaitai::kstream* p__io, nano_t::block_selector_t* p__parent, nano_t* p__root) : kaitai::kstruct(p__io) {
             m__parent = p__parent;
             m__root = p__root;
-            _read();
+
+            try {
+                _read();
+            } catch(...) {
+                _clean_up();
+                throw;
+            }
         }
 
         void nano_t::block_receive_t::_read() {
@@ -208,12 +284,22 @@ namespace nano {
         }
 
         nano_t::block_receive_t::~block_receive_t() {
+            _clean_up();
+        }
+
+        void nano_t::block_receive_t::_clean_up() {
         }
 
         nano_t::block_change_t::block_change_t(kaitai::kstream* p__io, nano_t::block_selector_t* p__parent, nano_t* p__root) : kaitai::kstruct(p__io) {
             m__parent = p__parent;
             m__root = p__root;
-            _read();
+
+            try {
+                _read();
+            } catch(...) {
+                _clean_up();
+                throw;
+            }
         }
 
         void nano_t::block_change_t::_read() {
@@ -224,13 +310,23 @@ namespace nano {
         }
 
         nano_t::block_change_t::~block_change_t() {
+            _clean_up();
+        }
+
+        void nano_t::block_change_t::_clean_up() {
         }
 
         nano_t::msg_bulk_pull_t::msg_bulk_pull_t(kaitai::kstream* p__io, nano_t* p__parent, nano_t* p__root) : kaitai::kstruct(p__io) {
             m__parent = p__parent;
             m__root = p__root;
             m_extended = 0;
-            _read();
+
+            try {
+                _read();
+            } catch(...) {
+                _clean_up();
+                throw;
+            }
         }
 
         void nano_t::msg_bulk_pull_t::_read() {
@@ -244,15 +340,27 @@ namespace nano {
         }
 
         nano_t::msg_bulk_pull_t::~msg_bulk_pull_t() {
+            _clean_up();
+        }
+
+        void nano_t::msg_bulk_pull_t::_clean_up() {
             if (!n_extended) {
-                delete m_extended;
+                if (m_extended) {
+                    delete m_extended; m_extended = 0;
+                }
             }
         }
 
         nano_t::msg_bulk_pull_t::extended_parameters_t::extended_parameters_t(kaitai::kstream* p__io, nano_t::msg_bulk_pull_t* p__parent, nano_t* p__root) : kaitai::kstruct(p__io) {
             m__parent = p__parent;
             m__root = p__root;
-            _read();
+
+            try {
+                _read();
+            } catch(...) {
+                _clean_up();
+                throw;
+            }
         }
 
         void nano_t::msg_bulk_pull_t::extended_parameters_t::_read() {
@@ -262,12 +370,22 @@ namespace nano {
         }
 
         nano_t::msg_bulk_pull_t::extended_parameters_t::~extended_parameters_t() {
+            _clean_up();
+        }
+
+        void nano_t::msg_bulk_pull_t::extended_parameters_t::_clean_up() {
         }
 
         nano_t::peer_t::peer_t(kaitai::kstream* p__io, nano_t::msg_keepalive_t* p__parent, nano_t* p__root) : kaitai::kstruct(p__io) {
             m__parent = p__parent;
             m__root = p__root;
-            _read();
+
+            try {
+                _read();
+            } catch(...) {
+                _clean_up();
+                throw;
+            }
         }
 
         void nano_t::peer_t::_read() {
@@ -276,25 +394,46 @@ namespace nano {
         }
 
         nano_t::peer_t::~peer_t() {
+            _clean_up();
         }
 
-        nano_t::msg_bulk_pull_blocks_t::msg_bulk_pull_blocks_t(kaitai::kstream* p__io, nano_t* p__parent, nano_t* p__root) : kaitai::kstruct(p__io) {
+        void nano_t::peer_t::_clean_up() {
+        }
+
+        nano_t::asc_pull_base_t::asc_pull_base_t(kaitai::kstream* p__io, kaitai::kstruct* p__parent, nano_t* p__root) : kaitai::kstruct(p__io) {
             m__parent = p__parent;
             m__root = p__root;
-            _read();
+
+            try {
+                _read();
+            } catch(...) {
+                _clean_up();
+                throw;
+            }
         }
 
-        void nano_t::msg_bulk_pull_blocks_t::_read() {
-            m_block_type = m__io->read_u1();
+        void nano_t::asc_pull_base_t::_read() {
+            m_type = static_cast<nano_t::enum_asc_pull_type_t>(m__io->read_u1());
+            m_id = m__io->read_u8be();
         }
 
-        nano_t::msg_bulk_pull_blocks_t::~msg_bulk_pull_blocks_t() {
+        nano_t::asc_pull_base_t::~asc_pull_base_t() {
+            _clean_up();
+        }
+
+        void nano_t::asc_pull_base_t::_clean_up() {
         }
 
         nano_t::block_open_t::block_open_t(kaitai::kstream* p__io, nano_t::block_selector_t* p__parent, nano_t* p__root) : kaitai::kstruct(p__io) {
             m__parent = p__parent;
             m__root = p__root;
-            _read();
+
+            try {
+                _read();
+            } catch(...) {
+                _clean_up();
+                throw;
+            }
         }
 
         void nano_t::block_open_t::_read() {
@@ -306,13 +445,23 @@ namespace nano {
         }
 
         nano_t::block_open_t::~block_open_t() {
+            _clean_up();
+        }
+
+        void nano_t::block_open_t::_clean_up() {
         }
 
         nano_t::ignore_until_eof_t::ignore_until_eof_t(kaitai::kstream* p__io, kaitai::kstruct* p__parent, nano_t* p__root) : kaitai::kstruct(p__io) {
             m__parent = p__parent;
             m__root = p__root;
             m_empty = 0;
-            _read();
+
+            try {
+                _read();
+            } catch(...) {
+                _clean_up();
+                throw;
+            }
         }
 
         void nano_t::ignore_until_eof_t::_read() {
@@ -333,8 +482,14 @@ namespace nano {
         }
 
         nano_t::ignore_until_eof_t::~ignore_until_eof_t() {
+            _clean_up();
+        }
+
+        void nano_t::ignore_until_eof_t::_clean_up() {
             if (!n_empty) {
-                delete m_empty;
+                if (m_empty) {
+                    delete m_empty; m_empty = 0;
+                }
             }
         }
 
@@ -343,31 +498,30 @@ namespace nano {
             m__root = p__root;
             m_common = 0;
             m_votebyhash = 0;
-            m_block = 0;
-            _read();
+
+            try {
+                _read();
+            } catch(...) {
+                _clean_up();
+                throw;
+            }
         }
 
         void nano_t::msg_confirm_ack_t::_read() {
             m_common = new vote_common_t(m__io, this, m__root);
-            n_votebyhash = true;
-            if (_root()->header()->block_type() == nano_t::ENUM_BLOCKTYPE_NOT_A_BLOCK) {
-                n_votebyhash = false;
-                m_votebyhash = new vote_by_hash_t(m__io, this, m__root);
-            }
-            n_block = true;
-            if (_root()->header()->block_type() != nano_t::ENUM_BLOCKTYPE_NOT_A_BLOCK) {
-                n_block = false;
-                m_block = new block_selector_t(_root()->header()->block_type_int(), m__io, this, m__root);
-            }
+            m_votebyhash = new vote_by_hash_t(m__io, this, m__root);
         }
 
         nano_t::msg_confirm_ack_t::~msg_confirm_ack_t() {
-            delete m_common;
-            if (!n_votebyhash) {
-                delete m_votebyhash;
+            _clean_up();
+        }
+
+        void nano_t::msg_confirm_ack_t::_clean_up() {
+            if (m_common) {
+                delete m_common; m_common = 0;
             }
-            if (!n_block) {
-                delete m_block;
+            if (m_votebyhash) {
+                delete m_votebyhash; m_votebyhash = 0;
             }
         }
 
@@ -376,7 +530,13 @@ namespace nano {
             m__root = p__root;
             m_query = 0;
             m_response = 0;
-            _read();
+
+            try {
+                _read();
+            } catch(...) {
+                _clean_up();
+                throw;
+            }
         }
 
         void nano_t::msg_node_id_handshake_t::_read() {
@@ -393,18 +553,32 @@ namespace nano {
         }
 
         nano_t::msg_node_id_handshake_t::~msg_node_id_handshake_t() {
+            _clean_up();
+        }
+
+        void nano_t::msg_node_id_handshake_t::_clean_up() {
             if (!n_query) {
-                delete m_query;
+                if (m_query) {
+                    delete m_query; m_query = 0;
+                }
             }
             if (!n_response) {
-                delete m_response;
+                if (m_response) {
+                    delete m_response; m_response = 0;
+                }
             }
         }
 
         nano_t::msg_frontier_req_t::msg_frontier_req_t(kaitai::kstream* p__io, nano_t* p__parent, nano_t* p__root) : kaitai::kstruct(p__io) {
             m__parent = p__parent;
             m__root = p__root;
-            _read();
+
+            try {
+                _read();
+            } catch(...) {
+                _clean_up();
+                throw;
+            }
         }
 
         void nano_t::msg_frontier_req_t::_read() {
@@ -414,13 +588,23 @@ namespace nano {
         }
 
         nano_t::msg_frontier_req_t::~msg_frontier_req_t() {
+            _clean_up();
+        }
+
+        void nano_t::msg_frontier_req_t::_clean_up() {
         }
 
         nano_t::msg_bulk_push_t::msg_bulk_push_t(kaitai::kstream* p__io, nano_t* p__parent, nano_t* p__root) : kaitai::kstruct(p__io) {
             m__parent = p__parent;
             m__root = p__root;
             m_entry = 0;
-            _read();
+
+            try {
+                _read();
+            } catch(...) {
+                _clean_up();
+                throw;
+            }
         }
 
         void nano_t::msg_bulk_push_t::_read() {
@@ -437,17 +621,29 @@ namespace nano {
         }
 
         nano_t::msg_bulk_push_t::~msg_bulk_push_t() {
-            for (std::vector<bulk_push_entry_t*>::iterator it = m_entry->begin(); it != m_entry->end(); ++it) {
-                delete *it;
+            _clean_up();
+        }
+
+        void nano_t::msg_bulk_push_t::_clean_up() {
+            if (m_entry) {
+                for (std::vector<bulk_push_entry_t*>::iterator it = m_entry->begin(); it != m_entry->end(); ++it) {
+                    delete *it;
+                }
+                delete m_entry; m_entry = 0;
             }
-            delete m_entry;
         }
 
         nano_t::msg_bulk_push_t::bulk_push_entry_t::bulk_push_entry_t(kaitai::kstream* p__io, nano_t::msg_bulk_push_t* p__parent, nano_t* p__root) : kaitai::kstruct(p__io) {
             m__parent = p__parent;
             m__root = p__root;
             m_block = 0;
-            _read();
+
+            try {
+                _read();
+            } catch(...) {
+                _clean_up();
+                throw;
+            }
         }
 
         void nano_t::msg_bulk_push_t::bulk_push_entry_t::_read() {
@@ -456,13 +652,25 @@ namespace nano {
         }
 
         nano_t::msg_bulk_push_t::bulk_push_entry_t::~bulk_push_entry_t() {
-            delete m_block;
+            _clean_up();
+        }
+
+        void nano_t::msg_bulk_push_t::bulk_push_entry_t::_clean_up() {
+            if (m_block) {
+                delete m_block; m_block = 0;
+            }
         }
 
         nano_t::node_id_response_t::node_id_response_t(kaitai::kstream* p__io, nano_t::msg_node_id_handshake_t* p__parent, nano_t* p__root) : kaitai::kstruct(p__io) {
             m__parent = p__parent;
             m__root = p__root;
-            _read();
+
+            try {
+                _read();
+            } catch(...) {
+                _clean_up();
+                throw;
+            }
         }
 
         void nano_t::node_id_response_t::_read() {
@@ -471,25 +679,222 @@ namespace nano {
         }
 
         nano_t::node_id_response_t::~node_id_response_t() {
+            _clean_up();
+        }
+
+        void nano_t::node_id_response_t::_clean_up() {
+        }
+
+        nano_t::msg_asc_pull_ack_t::msg_asc_pull_ack_t(kaitai::kstream* p__io, nano_t* p__parent, nano_t* p__root) : kaitai::kstruct(p__io) {
+            m__parent = p__parent;
+            m__root = p__root;
+            m_base = 0;
+            m_payload = 0;
+            m__io__raw_payload = 0;
+
+            try {
+                _read();
+            } catch(...) {
+                _clean_up();
+                throw;
+            }
+        }
+
+        void nano_t::msg_asc_pull_ack_t::_read() {
+            m_base = new asc_pull_base_t(m__io, this, m__root);
+            m__raw_payload = m__io->read_bytes(_root()->header()->asc_pull_size());
+            m__io__raw_payload = new kaitai::kstream(m__raw_payload);
+            m_payload = new asc_pull_ack_payload_t(m__io__raw_payload, this, m__root);
+        }
+
+        nano_t::msg_asc_pull_ack_t::~msg_asc_pull_ack_t() {
+            _clean_up();
+        }
+
+        void nano_t::msg_asc_pull_ack_t::_clean_up() {
+            if (m_base) {
+                delete m_base; m_base = 0;
+            }
+            if (m__io__raw_payload) {
+                delete m__io__raw_payload; m__io__raw_payload = 0;
+            }
+            if (m_payload) {
+                delete m_payload; m_payload = 0;
+            }
+        }
+
+        nano_t::msg_asc_pull_ack_t::account_info_ack_payload_t::account_info_ack_payload_t(kaitai::kstream* p__io, nano_t::msg_asc_pull_ack_t::asc_pull_ack_payload_t* p__parent, nano_t* p__root) : kaitai::kstruct(p__io) {
+            m__parent = p__parent;
+            m__root = p__root;
+
+            try {
+                _read();
+            } catch(...) {
+                _clean_up();
+                throw;
+            }
+        }
+
+        void nano_t::msg_asc_pull_ack_t::account_info_ack_payload_t::_read() {
+            m_account = m__io->read_bytes(32);
+            m_account_open = m__io->read_bytes(32);
+            m_account_head = m__io->read_bytes(32);
+            m_block_count = m__io->read_u8be();
+            m_conf_frontier = m__io->read_bytes(32);
+            m_conf_height = m__io->read_u8be();
+        }
+
+        nano_t::msg_asc_pull_ack_t::account_info_ack_payload_t::~account_info_ack_payload_t() {
+            _clean_up();
+        }
+
+        void nano_t::msg_asc_pull_ack_t::account_info_ack_payload_t::_clean_up() {
+        }
+
+        nano_t::msg_asc_pull_ack_t::blocks_ack_payload_t::blocks_ack_payload_t(kaitai::kstream* p__io, nano_t::msg_asc_pull_ack_t::asc_pull_ack_payload_t* p__parent, nano_t* p__root) : kaitai::kstruct(p__io) {
+            m__parent = p__parent;
+            m__root = p__root;
+            m_entry = 0;
+
+            try {
+                _read();
+            } catch(...) {
+                _clean_up();
+                throw;
+            }
+        }
+
+        void nano_t::msg_asc_pull_ack_t::blocks_ack_payload_t::_read() {
+            m_entry = new std::vector<asc_pull_entry_t*>();
+            {
+                int i = 0;
+                asc_pull_entry_t* _;
+                do {
+                    _ = new asc_pull_entry_t(m__io, this, m__root);
+                    m_entry->push_back(_);
+                    i++;
+                } while (!( ((_io()->is_eof()) || (_->block_type() == nano_t::ENUM_BLOCKTYPE_NOT_A_BLOCK)) ));
+            }
+        }
+
+        nano_t::msg_asc_pull_ack_t::blocks_ack_payload_t::~blocks_ack_payload_t() {
+            _clean_up();
+        }
+
+        void nano_t::msg_asc_pull_ack_t::blocks_ack_payload_t::_clean_up() {
+            if (m_entry) {
+                for (std::vector<asc_pull_entry_t*>::iterator it = m_entry->begin(); it != m_entry->end(); ++it) {
+                    delete *it;
+                }
+                delete m_entry; m_entry = 0;
+            }
+        }
+
+        nano_t::msg_asc_pull_ack_t::blocks_ack_payload_t::asc_pull_entry_t::asc_pull_entry_t(kaitai::kstream* p__io, nano_t::msg_asc_pull_ack_t::blocks_ack_payload_t* p__parent, nano_t* p__root) : kaitai::kstruct(p__io) {
+            m__parent = p__parent;
+            m__root = p__root;
+            m_block = 0;
+
+            try {
+                _read();
+            } catch(...) {
+                _clean_up();
+                throw;
+            }
+        }
+
+        void nano_t::msg_asc_pull_ack_t::blocks_ack_payload_t::asc_pull_entry_t::_read() {
+            m_block_type = m__io->read_u1();
+            m_block = new block_selector_t(block_type(), m__io, this, m__root);
+        }
+
+        nano_t::msg_asc_pull_ack_t::blocks_ack_payload_t::asc_pull_entry_t::~asc_pull_entry_t() {
+            _clean_up();
+        }
+
+        void nano_t::msg_asc_pull_ack_t::blocks_ack_payload_t::asc_pull_entry_t::_clean_up() {
+            if (m_block) {
+                delete m_block; m_block = 0;
+            }
+        }
+
+        nano_t::msg_asc_pull_ack_t::asc_pull_ack_payload_t::asc_pull_ack_payload_t(kaitai::kstream* p__io, nano_t::msg_asc_pull_ack_t* p__parent, nano_t* p__root) : kaitai::kstruct(p__io) {
+            m__parent = p__parent;
+            m__root = p__root;
+            m_account_info = 0;
+            m_blocks = 0;
+
+            try {
+                _read();
+            } catch(...) {
+                _clean_up();
+                throw;
+            }
+        }
+
+        void nano_t::msg_asc_pull_ack_t::asc_pull_ack_payload_t::_read() {
+            n_account_info = true;
+            if (_parent()->base()->type() == nano_t::ENUM_ASC_PULL_TYPE_ACCOUNT_PULL_TYPE) {
+                n_account_info = false;
+                m_account_info = new account_info_ack_payload_t(m__io, this, m__root);
+            }
+            n_blocks = true;
+            if (_parent()->base()->type() == nano_t::ENUM_ASC_PULL_TYPE_BLOCK_PULL_TYPE) {
+                n_blocks = false;
+                m_blocks = new blocks_ack_payload_t(m__io, this, m__root);
+            }
+        }
+
+        nano_t::msg_asc_pull_ack_t::asc_pull_ack_payload_t::~asc_pull_ack_payload_t() {
+            _clean_up();
+        }
+
+        void nano_t::msg_asc_pull_ack_t::asc_pull_ack_payload_t::_clean_up() {
+            if (!n_account_info) {
+                if (m_account_info) {
+                    delete m_account_info; m_account_info = 0;
+                }
+            }
+            if (!n_blocks) {
+                if (m_blocks) {
+                    delete m_blocks; m_blocks = 0;
+                }
+            }
         }
 
         nano_t::bulk_push_response_t::bulk_push_response_t(kaitai::kstream* p__io, kaitai::kstruct* p__parent, nano_t* p__root) : kaitai::kstruct(p__io) {
             m__parent = p__parent;
             m__root = p__root;
-            _read();
+
+            try {
+                _read();
+            } catch(...) {
+                _clean_up();
+                throw;
+            }
         }
 
         void nano_t::bulk_push_response_t::_read() {
         }
 
         nano_t::bulk_push_response_t::~bulk_push_response_t() {
+            _clean_up();
+        }
+
+        void nano_t::bulk_push_response_t::_clean_up() {
         }
 
         nano_t::bulk_pull_response_t::bulk_pull_response_t(kaitai::kstream* p__io, kaitai::kstruct* p__parent, nano_t* p__root) : kaitai::kstruct(p__io) {
             m__parent = p__parent;
             m__root = p__root;
             m_entry = 0;
-            _read();
+
+            try {
+                _read();
+            } catch(...) {
+                _clean_up();
+                throw;
+            }
         }
 
         void nano_t::bulk_pull_response_t::_read() {
@@ -506,17 +911,29 @@ namespace nano {
         }
 
         nano_t::bulk_pull_response_t::~bulk_pull_response_t() {
-            for (std::vector<bulk_pull_entry_t*>::iterator it = m_entry->begin(); it != m_entry->end(); ++it) {
-                delete *it;
+            _clean_up();
+        }
+
+        void nano_t::bulk_pull_response_t::_clean_up() {
+            if (m_entry) {
+                for (std::vector<bulk_pull_entry_t*>::iterator it = m_entry->begin(); it != m_entry->end(); ++it) {
+                    delete *it;
+                }
+                delete m_entry; m_entry = 0;
             }
-            delete m_entry;
         }
 
         nano_t::bulk_pull_response_t::bulk_pull_entry_t::bulk_pull_entry_t(kaitai::kstream* p__io, kaitai::kstruct* p__parent, nano_t* p__root) : kaitai::kstruct(p__io) {
             m__parent = p__parent;
             m__root = p__root;
             m_block = 0;
-            _read();
+
+            try {
+                _read();
+            } catch(...) {
+                _clean_up();
+                throw;
+            }
         }
 
         void nano_t::bulk_pull_response_t::bulk_pull_entry_t::_read() {
@@ -525,14 +942,26 @@ namespace nano {
         }
 
         nano_t::bulk_pull_response_t::bulk_pull_entry_t::~bulk_pull_entry_t() {
-            delete m_block;
+            _clean_up();
+        }
+
+        void nano_t::bulk_pull_response_t::bulk_pull_entry_t::_clean_up() {
+            if (m_block) {
+                delete m_block; m_block = 0;
+            }
         }
 
         nano_t::msg_publish_t::msg_publish_t(kaitai::kstream* p__io, nano_t* p__parent, nano_t* p__root) : kaitai::kstruct(p__io) {
             m__parent = p__parent;
             m__root = p__root;
             m_body = 0;
-            _read();
+
+            try {
+                _read();
+            } catch(...) {
+                _clean_up();
+                throw;
+            }
         }
 
         void nano_t::msg_publish_t::_read() {
@@ -540,13 +969,25 @@ namespace nano {
         }
 
         nano_t::msg_publish_t::~msg_publish_t() {
-            delete m_body;
+            _clean_up();
+        }
+
+        void nano_t::msg_publish_t::_clean_up() {
+            if (m_body) {
+                delete m_body; m_body = 0;
+            }
         }
 
         nano_t::block_state_t::block_state_t(kaitai::kstream* p__io, nano_t::block_selector_t* p__parent, nano_t* p__root) : kaitai::kstruct(p__io) {
             m__parent = p__parent;
             m__root = p__root;
-            _read();
+
+            try {
+                _read();
+            } catch(...) {
+                _clean_up();
+                throw;
+            }
         }
 
         void nano_t::block_state_t::_read() {
@@ -560,12 +1001,22 @@ namespace nano {
         }
 
         nano_t::block_state_t::~block_state_t() {
+            _clean_up();
+        }
+
+        void nano_t::block_state_t::_clean_up() {
         }
 
         nano_t::hash_pair_t::hash_pair_t(kaitai::kstream* p__io, nano_t::confirm_request_by_hash_t* p__parent, nano_t* p__root) : kaitai::kstruct(p__io) {
             m__parent = p__parent;
             m__root = p__root;
-            _read();
+
+            try {
+                _read();
+            } catch(...) {
+                _clean_up();
+                throw;
+            }
         }
 
         void nano_t::hash_pair_t::_read() {
@@ -574,6 +1025,10 @@ namespace nano {
         }
 
         nano_t::hash_pair_t::~hash_pair_t() {
+            _clean_up();
+        }
+
+        void nano_t::hash_pair_t::_clean_up() {
         }
 
         nano_t::bulk_pull_account_response_t::bulk_pull_account_response_t(uint8_t p_flags, kaitai::kstream* p__io, kaitai::kstruct* p__parent, nano_t* p__root) : kaitai::kstruct(p__io) {
@@ -582,7 +1037,13 @@ namespace nano {
             m_flags = p_flags;
             m_frontier_entry = 0;
             m_pending_entry = 0;
-            _read();
+
+            try {
+                _read();
+            } catch(...) {
+                _clean_up();
+                throw;
+            }
         }
 
         void nano_t::bulk_pull_account_response_t::_read() {
@@ -600,17 +1061,31 @@ namespace nano {
         }
 
         nano_t::bulk_pull_account_response_t::~bulk_pull_account_response_t() {
-            delete m_frontier_entry;
-            for (std::vector<bulk_pull_account_entry_t*>::iterator it = m_pending_entry->begin(); it != m_pending_entry->end(); ++it) {
-                delete *it;
+            _clean_up();
+        }
+
+        void nano_t::bulk_pull_account_response_t::_clean_up() {
+            if (m_frontier_entry) {
+                delete m_frontier_entry; m_frontier_entry = 0;
             }
-            delete m_pending_entry;
+            if (m_pending_entry) {
+                for (std::vector<bulk_pull_account_entry_t*>::iterator it = m_pending_entry->begin(); it != m_pending_entry->end(); ++it) {
+                    delete *it;
+                }
+                delete m_pending_entry; m_pending_entry = 0;
+            }
         }
 
         nano_t::bulk_pull_account_response_t::frontier_balance_entry_t::frontier_balance_entry_t(kaitai::kstream* p__io, kaitai::kstruct* p__parent, nano_t* p__root) : kaitai::kstruct(p__io) {
             m__parent = p__parent;
             m__root = p__root;
-            _read();
+
+            try {
+                _read();
+            } catch(...) {
+                _clean_up();
+                throw;
+            }
         }
 
         void nano_t::bulk_pull_account_response_t::frontier_balance_entry_t::_read() {
@@ -619,6 +1094,10 @@ namespace nano {
         }
 
         nano_t::bulk_pull_account_response_t::frontier_balance_entry_t::~frontier_balance_entry_t() {
+            _clean_up();
+        }
+
+        void nano_t::bulk_pull_account_response_t::frontier_balance_entry_t::_clean_up() {
         }
 
         nano_t::bulk_pull_account_response_t::bulk_pull_account_entry_t::bulk_pull_account_entry_t(uint8_t p_flags, kaitai::kstream* p__io, kaitai::kstruct* p__parent, nano_t* p__root) : kaitai::kstruct(p__io) {
@@ -627,7 +1106,13 @@ namespace nano {
             m_flags = p_flags;
             f_pending_address_only = false;
             f_pending_include_address = false;
-            _read();
+
+            try {
+                _read();
+            } catch(...) {
+                _clean_up();
+                throw;
+            }
         }
 
         void nano_t::bulk_pull_account_response_t::bulk_pull_account_entry_t::_read() {
@@ -649,6 +1134,10 @@ namespace nano {
         }
 
         nano_t::bulk_pull_account_response_t::bulk_pull_account_entry_t::~bulk_pull_account_entry_t() {
+            _clean_up();
+        }
+
+        void nano_t::bulk_pull_account_response_t::bulk_pull_account_entry_t::_clean_up() {
             if (!n_hash) {
             }
             if (!n_amount) {
@@ -677,7 +1166,13 @@ namespace nano {
             m__parent = p__parent;
             m__root = p__root;
             m_peers = 0;
-            _read();
+
+            try {
+                _read();
+            } catch(...) {
+                _clean_up();
+                throw;
+            }
         }
 
         void nano_t::msg_keepalive_t::_read() {
@@ -698,11 +1193,17 @@ namespace nano {
         }
 
         nano_t::msg_keepalive_t::~msg_keepalive_t() {
+            _clean_up();
+        }
+
+        void nano_t::msg_keepalive_t::_clean_up() {
             if (!n_peers) {
-                for (std::vector<peer_t*>::iterator it = m_peers->begin(); it != m_peers->end(); ++it) {
-                    delete *it;
+                if (m_peers) {
+                    for (std::vector<peer_t*>::iterator it = m_peers->begin(); it != m_peers->end(); ++it) {
+                        delete *it;
+                    }
+                    delete m_peers; m_peers = 0;
                 }
-                delete m_peers;
             }
         }
 
@@ -711,7 +1212,13 @@ namespace nano {
             m__root = p__root;
             m_reqbyhash = 0;
             m_block = 0;
-            _read();
+
+            try {
+                _read();
+            } catch(...) {
+                _clean_up();
+                throw;
+            }
         }
 
         void nano_t::msg_confirm_req_t::_read() {
@@ -728,18 +1235,32 @@ namespace nano {
         }
 
         nano_t::msg_confirm_req_t::~msg_confirm_req_t() {
+            _clean_up();
+        }
+
+        void nano_t::msg_confirm_req_t::_clean_up() {
             if (!n_reqbyhash) {
-                delete m_reqbyhash;
+                if (m_reqbyhash) {
+                    delete m_reqbyhash; m_reqbyhash = 0;
+                }
             }
             if (!n_block) {
-                delete m_block;
+                if (m_block) {
+                    delete m_block; m_block = 0;
+                }
             }
         }
 
         nano_t::msg_bulk_pull_account_t::msg_bulk_pull_account_t(kaitai::kstream* p__io, nano_t* p__parent, nano_t* p__root) : kaitai::kstruct(p__io) {
             m__parent = p__parent;
             m__root = p__root;
-            _read();
+
+            try {
+                _read();
+            } catch(...) {
+                _clean_up();
+                throw;
+            }
         }
 
         void nano_t::msg_bulk_pull_account_t::_read() {
@@ -749,13 +1270,23 @@ namespace nano {
         }
 
         nano_t::msg_bulk_pull_account_t::~msg_bulk_pull_account_t() {
+            _clean_up();
+        }
+
+        void nano_t::msg_bulk_pull_account_t::_clean_up() {
         }
 
         nano_t::vote_by_hash_t::vote_by_hash_t(kaitai::kstream* p__io, nano_t::msg_confirm_ack_t* p__parent, nano_t* p__root) : kaitai::kstruct(p__io) {
             m__parent = p__parent;
             m__root = p__root;
             m_hashes = 0;
-            _read();
+
+            try {
+                _read();
+            } catch(...) {
+                _clean_up();
+                throw;
+            }
         }
 
         void nano_t::vote_by_hash_t::_read() {
@@ -776,29 +1307,64 @@ namespace nano {
         }
 
         nano_t::vote_by_hash_t::~vote_by_hash_t() {
+            _clean_up();
+        }
+
+        void nano_t::vote_by_hash_t::_clean_up() {
             if (!n_hashes) {
-                delete m_hashes;
+                if (m_hashes) {
+                    delete m_hashes; m_hashes = 0;
+                }
             }
         }
 
         nano_t::vote_common_t::vote_common_t(kaitai::kstream* p__io, nano_t::msg_confirm_ack_t* p__parent, nano_t* p__root) : kaitai::kstruct(p__io) {
             m__parent = p__parent;
             m__root = p__root;
-            _read();
+            f_timestamp = false;
+            f_vote_duration_bits = false;
+
+            try {
+                _read();
+            } catch(...) {
+                _clean_up();
+                throw;
+            }
         }
 
         void nano_t::vote_common_t::_read() {
             m_account = m__io->read_bytes(32);
             m_signature = m__io->read_bytes(64);
-            m_sequence = m__io->read_u8le();
+            m_timestamp_and_vote_duration = m__io->read_u8le();
         }
 
         nano_t::vote_common_t::~vote_common_t() {
+            _clean_up();
+        }
+
+        void nano_t::vote_common_t::_clean_up() {
+        }
+
+        int32_t nano_t::vote_common_t::timestamp() {
+            if (f_timestamp)
+                return m_timestamp;
+            m_timestamp = (timestamp_and_vote_duration() & 18446744073709551600ULL);
+            f_timestamp = true;
+            return m_timestamp;
+        }
+
+        int32_t nano_t::vote_common_t::vote_duration_bits() {
+            if (f_vote_duration_bits)
+                return m_vote_duration_bits;
+            m_vote_duration_bits = (timestamp_and_vote_duration() & 15);
+            f_vote_duration_bits = true;
+            return m_vote_duration_bits;
         }
 
         nano_t::message_header_t::message_header_t(kaitai::kstream* p__io, nano_t* p__parent, nano_t* p__root) : kaitai::kstruct(p__io) {
             m__parent = p__parent;
             m__root = p__root;
+            f_bulk_pull_ascending_flag = false;
             f_response_flag = false;
             f_block_type_int = false;
             f_telemetry_size = false;
@@ -806,7 +1372,15 @@ namespace nano {
             f_block_type = false;
             f_item_count_int = false;
             f_query_flag = false;
-            _read();
+            f_confirmed_present = false;
+            f_asc_pull_size = false;
+
+            try {
+                _read();
+            } catch(...) {
+                _clean_up();
+                throw;
+            }
         }
 
         void nano_t::message_header_t::_read() {
@@ -820,6 +1394,18 @@ namespace nano {
         }
 
         nano_t::message_header_t::~message_header_t() {
+            _clean_up();
+        }
+
+        void nano_t::message_header_t::_clean_up() {
+        }
+
+        int32_t nano_t::message_header_t::bulk_pull_ascending_flag() {
+            if (f_bulk_pull_ascending_flag)
+                return m_bulk_pull_ascending_flag;
+            m_bulk_pull_ascending_flag = (extensions() & 2);
+            f_bulk_pull_ascending_flag = true;
+            return m_bulk_pull_ascending_flag;
         }
 
         int32_t nano_t::message_header_t::response_flag() {
@@ -841,7 +1427,7 @@ namespace nano {
         int32_t nano_t::message_header_t::telemetry_size() {
             if (f_telemetry_size)
                 return m_telemetry_size;
-            m_telemetry_size = (extensions() & 2047);
+            m_telemetry_size = (extensions() & 1023);
             f_telemetry_size = true;
             return m_telemetry_size;
         }
@@ -878,11 +1464,33 @@ namespace nano {
             return m_query_flag;
         }
 
+        int32_t nano_t::message_header_t::confirmed_present() {
+            if (f_confirmed_present)
+                return m_confirmed_present;
+            m_confirmed_present = (extensions() & 2);
+            f_confirmed_present = true;
+            return m_confirmed_present;
+        }
+
+        int32_t nano_t::message_header_t::asc_pull_size() {
+            if (f_asc_pull_size)
+                return m_asc_pull_size;
+            m_asc_pull_size = (extensions() & 65535);
+            f_asc_pull_size = true;
+            return m_asc_pull_size;
+        }
+
         nano_t::frontier_response_t::frontier_response_t(kaitai::kstream* p__io, kaitai::kstruct* p__parent, nano_t* p__root) : kaitai::kstruct(p__io) {
             m__parent = p__parent;
             m__root = p__root;
             m_entry = 0;
-            _read();
+
+            try {
+                _read();
+            } catch(...) {
+                _clean_up();
+                throw;
+            }
         }
 
         void nano_t::frontier_response_t::_read() {
@@ -899,16 +1507,28 @@ namespace nano {
         }
 
         nano_t::frontier_response_t::~frontier_response_t() {
-            for (std::vector<frontier_entry_t*>::iterator it = m_entry->begin(); it != m_entry->end(); ++it) {
-                delete *it;
+            _clean_up();
+        }
+
+        void nano_t::frontier_response_t::_clean_up() {
+            if (m_entry) {
+                for (std::vector<frontier_entry_t*>::iterator it = m_entry->begin(); it != m_entry->end(); ++it) {
+                    delete *it;
+                }
+                delete m_entry; m_entry = 0;
             }
-            delete m_entry;
         }
 
         nano_t::frontier_response_t::frontier_entry_t::frontier_entry_t(kaitai::kstream* p__io, kaitai::kstruct* p__parent, nano_t* p__root) : kaitai::kstruct(p__io) {
             m__parent = p__parent;
             m__root = p__root;
-            _read();
+
+            try {
+                _read();
+            } catch(...) {
+                _clean_up();
+                throw;
+            }
         }
 
         void nano_t::frontier_response_t::frontier_entry_t::_read() {
@@ -917,12 +1537,154 @@ namespace nano {
         }
 
         nano_t::frontier_response_t::frontier_entry_t::~frontier_entry_t() {
+            _clean_up();
+        }
+
+        void nano_t::frontier_response_t::frontier_entry_t::_clean_up() {
+        }
+
+        nano_t::msg_asc_pull_req_t::msg_asc_pull_req_t(kaitai::kstream* p__io, nano_t* p__parent, nano_t* p__root) : kaitai::kstruct(p__io) {
+            m__parent = p__parent;
+            m__root = p__root;
+            m_base = 0;
+            m_payload = 0;
+            m__io__raw_payload = 0;
+
+            try {
+                _read();
+            } catch(...) {
+                _clean_up();
+                throw;
+            }
+        }
+
+        void nano_t::msg_asc_pull_req_t::_read() {
+            m_base = new asc_pull_base_t(m__io, this, m__root);
+            m__raw_payload = m__io->read_bytes(_root()->header()->asc_pull_size());
+            m__io__raw_payload = new kaitai::kstream(m__raw_payload);
+            m_payload = new asc_pull_req_payload_t(m__io__raw_payload, this, m__root);
+        }
+
+        nano_t::msg_asc_pull_req_t::~msg_asc_pull_req_t() {
+            _clean_up();
+        }
+
+        void nano_t::msg_asc_pull_req_t::_clean_up() {
+            if (m_base) {
+                delete m_base; m_base = 0;
+            }
+            if (m__io__raw_payload) {
+                delete m__io__raw_payload; m__io__raw_payload = 0;
+            }
+            if (m_payload) {
+                delete m_payload; m_payload = 0;
+            }
+        }
+
+        nano_t::msg_asc_pull_req_t::account_info_req_payload_t::account_info_req_payload_t(kaitai::kstream* p__io, nano_t::msg_asc_pull_req_t::asc_pull_req_payload_t* p__parent, nano_t* p__root) : kaitai::kstruct(p__io) {
+            m__parent = p__parent;
+            m__root = p__root;
+
+            try {
+                _read();
+            } catch(...) {
+                _clean_up();
+                throw;
+            }
+        }
+
+        void nano_t::msg_asc_pull_req_t::account_info_req_payload_t::_read() {
+            m_start = m__io->read_bytes(32);
+            m_start_type = static_cast<nano_t::enum_asc_hash_type_t>(m__io->read_u1());
+        }
+
+        nano_t::msg_asc_pull_req_t::account_info_req_payload_t::~account_info_req_payload_t() {
+            _clean_up();
+        }
+
+        void nano_t::msg_asc_pull_req_t::account_info_req_payload_t::_clean_up() {
+        }
+
+        nano_t::msg_asc_pull_req_t::blocks_req_payload_t::blocks_req_payload_t(kaitai::kstream* p__io, nano_t::msg_asc_pull_req_t::asc_pull_req_payload_t* p__parent, nano_t* p__root) : kaitai::kstruct(p__io) {
+            m__parent = p__parent;
+            m__root = p__root;
+
+            try {
+                _read();
+            } catch(...) {
+                _clean_up();
+                throw;
+            }
+        }
+
+        void nano_t::msg_asc_pull_req_t::blocks_req_payload_t::_read() {
+            m_start = m__io->read_bytes(32);
+            m_count = m__io->read_u1();
+            m_start_type = static_cast<nano_t::enum_asc_hash_type_t>(m__io->read_u1());
+        }
+
+        nano_t::msg_asc_pull_req_t::blocks_req_payload_t::~blocks_req_payload_t() {
+            _clean_up();
+        }
+
+        void nano_t::msg_asc_pull_req_t::blocks_req_payload_t::_clean_up() {
+        }
+
+        nano_t::msg_asc_pull_req_t::asc_pull_req_payload_t::asc_pull_req_payload_t(kaitai::kstream* p__io, nano_t::msg_asc_pull_req_t* p__parent, nano_t* p__root) : kaitai::kstruct(p__io) {
+            m__parent = p__parent;
+            m__root = p__root;
+            m_account_info = 0;
+            m_blocks = 0;
+
+            try {
+                _read();
+            } catch(...) {
+                _clean_up();
+                throw;
+            }
+        }
+
+        void nano_t::msg_asc_pull_req_t::asc_pull_req_payload_t::_read() {
+            n_account_info = true;
+            if (_parent()->base()->type() == nano_t::ENUM_ASC_PULL_TYPE_ACCOUNT_PULL_TYPE) {
+                n_account_info = false;
+                m_account_info = new account_info_req_payload_t(m__io, this, m__root);
+            }
+            n_blocks = true;
+            if (_parent()->base()->type() == nano_t::ENUM_ASC_PULL_TYPE_BLOCK_PULL_TYPE) {
+                n_blocks = false;
+                m_blocks = new blocks_req_payload_t(m__io, this, m__root);
+            }
+        }
+
+        nano_t::msg_asc_pull_req_t::asc_pull_req_payload_t::~asc_pull_req_payload_t() {
+            _clean_up();
+        }
+
+        void nano_t::msg_asc_pull_req_t::asc_pull_req_payload_t::_clean_up() {
+            if (!n_account_info) {
+                if (m_account_info) {
+                    delete m_account_info; m_account_info = 0;
+                }
+            }
+            if (!n_blocks) {
+                if (m_blocks) {
+                    delete m_blocks; m_blocks = 0;
+                }
+            }
         }
 
         nano_t::msg_telemetry_ack_t::msg_telemetry_ack_t(kaitai::kstream* p__io, nano_t* p__parent, nano_t* p__root) : kaitai::kstruct(p__io) {
             m__parent = p__parent;
             m__root = p__root;
-            _read();
+            m_unknown_data = 0;
+
+            try {
+                _read();
+            } catch(...) {
+                _clean_up();
+                throw;
+            }
         }
 
         void nano_t::msg_telemetry_ack_t::_read() {
@@ -933,9 +1695,9 @@ namespace nano {
             m_uncheckedcount = m__io->read_u8be();
             m_accountcount = m__io->read_u8be();
             m_bandwidthcap = m__io->read_u8be();
-            m_uptime = m__io->read_u8be();
             m_peercount = m__io->read_u4be();
             m_protocolversion = m__io->read_u1();
+            m_uptime = m__io->read_u8be();
             m_genesisblock = m__io->read_bytes(32);
             m_majorversion = m__io->read_u1();
             m_minorversion = m__io->read_u1();
@@ -944,9 +1706,32 @@ namespace nano {
             m_maker = m__io->read_u1();
             m_timestamp = m__io->read_u8be();
             m_activedifficulty = m__io->read_u8be();
+            n_unknown_data = true;
+            if (_io()->pos() < _root()->header()->telemetry_size()) {
+                n_unknown_data = false;
+                m_unknown_data = new std::vector<uint64_t>();
+                {
+                    int i = 0;
+                    uint64_t _;
+                    do {
+                        _ = m__io->read_u8le();
+                        m_unknown_data->push_back(_);
+                        i++;
+                    } while (!(_io()->pos() == _root()->header()->telemetry_size()));
+                }
+            }
         }
 
         nano_t::msg_telemetry_ack_t::~msg_telemetry_ack_t() {
+            _clean_up();
+        }
+
+        void nano_t::msg_telemetry_ack_t::_clean_up() {
+            if (!n_unknown_data) {
+                if (m_unknown_data) {
+                    delete m_unknown_data; m_unknown_data = 0;
+                }
+            }
         }
 
         std::string nano_t::const_block_zero() {

--- a/src/nano.h
+++ b/src/nano.h
@@ -4,12 +4,11 @@
 // This is a generated file! Please edit source .ksy file and use kaitai-struct-compiler to rebuild
 
 #include "kaitai/kaitaistruct.h"
-
 #include <stdint.h>
 #include <vector>
 
-#if KAITAI_STRUCT_VERSION < 7000L
-#error "Incompatible Kaitai Struct C++/STL API: version 0.7 or later is required"
+#if KAITAI_STRUCT_VERSION < 9000L
+#error "Incompatible Kaitai Struct C++/STL API: version 0.9 or later is required"
 #endif
 namespace nano {
     namespace protocol {
@@ -26,7 +25,7 @@ namespace nano {
             class block_change_t;
             class msg_bulk_pull_t;
             class peer_t;
-            class msg_bulk_pull_blocks_t;
+            class asc_pull_base_t;
             class block_open_t;
             class ignore_until_eof_t;
             class msg_confirm_ack_t;
@@ -34,6 +33,7 @@ namespace nano {
             class msg_frontier_req_t;
             class msg_bulk_push_t;
             class node_id_response_t;
+            class msg_asc_pull_ack_t;
             class bulk_push_response_t;
             class bulk_pull_response_t;
             class msg_publish_t;
@@ -47,6 +47,7 @@ namespace nano {
             class vote_common_t;
             class message_header_t;
             class frontier_response_t;
+            class msg_asc_pull_req_t;
             class msg_telemetry_ack_t;
 
             enum enum_blocktype_t {
@@ -69,17 +70,23 @@ namespace nano {
                 ENUM_MSGTYPE_BULK_PULL = 6,
                 ENUM_MSGTYPE_BULK_PUSH = 7,
                 ENUM_MSGTYPE_FRONTIER_REQ = 8,
-                ENUM_MSGTYPE_BULK_PULL_BLOCKS = 9,
                 ENUM_MSGTYPE_NODE_ID_HANDSHAKE = 10,
                 ENUM_MSGTYPE_BULK_PULL_ACCOUNT = 11,
                 ENUM_MSGTYPE_TELEMETRY_REQ = 12,
-                ENUM_MSGTYPE_TELEMETRY_ACK = 13
+                ENUM_MSGTYPE_TELEMETRY_ACK = 13,
+                ENUM_MSGTYPE_ASC_PULL_REQ = 14,
+                ENUM_MSGTYPE_ASC_PULL_ACK = 15
             };
 
             enum enum_network_t {
                 ENUM_NETWORK_NETWORK_TEST = 65,
                 ENUM_NETWORK_NETWORK_BETA = 66,
                 ENUM_NETWORK_NETWORK_LIVE = 67
+            };
+
+            enum enum_asc_hash_type_t {
+                ENUM_ASC_HASH_TYPE_ACCOUNT_HASH_TYPE = 0,
+                ENUM_ASC_HASH_TYPE_BLOCK_HASH_TYPE = 1
             };
 
             enum enum_bulk_pull_account_t {
@@ -89,13 +96,20 @@ namespace nano {
             };
 
             enum protocol_version_t {
-                PROTOCOL_VERSION_VALUE = 18
+                PROTOCOL_VERSION_VALUE = 19
+            };
+
+            enum enum_asc_pull_type_t {
+                ENUM_ASC_PULL_TYPE_INVALID = 0,
+                ENUM_ASC_PULL_TYPE_BLOCK_PULL_TYPE = 1,
+                ENUM_ASC_PULL_TYPE_ACCOUNT_PULL_TYPE = 2
             };
 
             nano_t(kaitai::kstream* p__io, kaitai::kstruct* p__parent = 0, nano_t* p__root = 0);
 
         private:
             void _read();
+            void _clean_up();
 
         public:
             ~nano_t();
@@ -108,6 +122,7 @@ namespace nano {
 
             private:
                 void _read();
+                void _clean_up();
 
             public:
                 ~block_send_t();
@@ -124,36 +139,36 @@ namespace nano {
             public:
 
                 /**
-                 * Hash of the previous block
-                 */
+                * Hash of the previous block
+                */
                 std::string previous() const { return m_previous; }
 
                 /**
-                 * Public key of destination account
-                 */
+                * Public key of destination account
+                */
                 std::string destination() const { return m_destination; }
 
                 /**
-                 * 128-bit big endian balance
-                 */
+                * 128-bit big endian balance
+                */
                 std::string balance() const { return m_balance; }
 
                 /**
-                 * ed25519-blake2b signature
-                 */
+                * ed25519-blake2b signature
+                */
                 std::string signature() const { return m_signature; }
 
                 /**
-                 * Proof of work
-                 */
+                * Proof of work
+                */
                 uint64_t work() const { return m_work; }
                 nano_t* _root() const { return m__root; }
                 nano_t::block_selector_t* _parent() const { return m__parent; }
             };
 
             /**
-             * A sequence of hash,root pairs
-             */
+            * A sequence of hash,root pairs
+            */
 
             class confirm_request_by_hash_t : public kaitai::kstruct {
 
@@ -163,6 +178,7 @@ namespace nano {
 
             private:
                 void _read();
+                void _clean_up();
 
             public:
                 ~confirm_request_by_hash_t();
@@ -181,16 +197,16 @@ namespace nano {
             public:
 
                 /**
-                 * Up to "count" pairs of hash (first) and root (second), where count is read from header.
-                 */
+                * Up to "count" pairs of hash (first) and root (second), where count is read from header.
+                */
                 std::vector<hash_pair_t*>* pairs() const { return m_pairs; }
                 nano_t* _root() const { return m__root; }
                 nano_t::msg_confirm_req_t* _parent() const { return m__parent; }
             };
 
             /**
-             * Request node telemetry metrics
-             */
+            * Request node telemetry metrics
+            */
 
             class msg_telemetry_req_t : public kaitai::kstruct {
 
@@ -200,6 +216,7 @@ namespace nano {
 
             private:
                 void _read();
+                void _clean_up();
 
             public:
                 ~msg_telemetry_req_t();
@@ -214,8 +231,8 @@ namespace nano {
             };
 
             /**
-             * Selects a block based on the argument
-             */
+            * Selects a block based on the argument
+            */
 
             class block_selector_t : public kaitai::kstruct {
 
@@ -225,6 +242,7 @@ namespace nano {
 
             private:
                 void _read();
+                void _clean_up();
 
             public:
                 ~block_selector_t();
@@ -250,6 +268,7 @@ namespace nano {
 
             private:
                 void _read();
+                void _clean_up();
 
             public:
                 ~node_id_query_t();
@@ -262,8 +281,8 @@ namespace nano {
             public:
 
                 /**
-                 * Per-endpoint random number
-                 */
+                * Per-endpoint random number
+                */
                 std::string cookie() const { return m_cookie; }
                 nano_t* _root() const { return m__root; }
                 nano_t::msg_node_id_handshake_t* _parent() const { return m__parent; }
@@ -277,6 +296,7 @@ namespace nano {
 
             private:
                 void _read();
+                void _clean_up();
 
             public:
                 ~block_receive_t();
@@ -292,23 +312,23 @@ namespace nano {
             public:
 
                 /**
-                 * Hash of the previous block
-                 */
+                * Hash of the previous block
+                */
                 std::string previous() const { return m_previous; }
 
                 /**
-                 * Hash of the source send block
-                 */
+                * Hash of the source send block
+                */
                 std::string source() const { return m_source; }
 
                 /**
-                 * ed25519-blake2b signature
-                 */
+                * ed25519-blake2b signature
+                */
                 std::string signature() const { return m_signature; }
 
                 /**
-                 * Proof of work
-                 */
+                * Proof of work
+                */
                 uint64_t work() const { return m_work; }
                 nano_t* _root() const { return m__root; }
                 nano_t::block_selector_t* _parent() const { return m__parent; }
@@ -322,6 +342,7 @@ namespace nano {
 
             private:
                 void _read();
+                void _clean_up();
 
             public:
                 ~block_change_t();
@@ -337,31 +358,31 @@ namespace nano {
             public:
 
                 /**
-                 * Hash of the previous block
-                 */
+                * Hash of the previous block
+                */
                 std::string previous() const { return m_previous; }
 
                 /**
-                 * Public key of new representative account
-                 */
+                * Public key of new representative account
+                */
                 std::string representative() const { return m_representative; }
 
                 /**
-                 * ed25519-blake2b signature
-                 */
+                * ed25519-blake2b signature
+                */
                 std::string signature() const { return m_signature; }
 
                 /**
-                 * Proof of work
-                 */
+                * Proof of work
+                */
                 uint64_t work() const { return m_work; }
                 nano_t* _root() const { return m__root; }
                 nano_t::block_selector_t* _parent() const { return m__parent; }
             };
 
             /**
-             * Bulk pull request.
-             */
+            * Bulk pull request.
+            */
 
             class msg_bulk_pull_t : public kaitai::kstruct {
 
@@ -372,6 +393,7 @@ namespace nano {
 
             private:
                 void _read();
+                void _clean_up();
 
             public:
                 ~msg_bulk_pull_t();
@@ -384,6 +406,7 @@ namespace nano {
 
                 private:
                     void _read();
+                    void _clean_up();
 
                 public:
                     ~extended_parameters_t();
@@ -398,18 +421,18 @@ namespace nano {
                 public:
 
                     /**
-                     * Must be 0
-                     */
+                    * Must be 0
+                    */
                     uint8_t zero() const { return m_zero; }
 
                     /**
-                     * little endian "count" parameter to limit the response set.
-                     */
+                    * little endian "count" parameter to limit the response set.
+                    */
                     uint32_t count() const { return m_count; }
 
                     /**
-                     * Reserved extended parameter bytes
-                     */
+                    * Reserved extended parameter bytes
+                    */
                     std::string reserved() const { return m_reserved; }
                     nano_t* _root() const { return m__root; }
                     nano_t::msg_bulk_pull_t* _parent() const { return m__parent; }
@@ -431,13 +454,13 @@ namespace nano {
             public:
 
                 /**
-                 * Account public key or block hash.
-                 */
+                * Account public key or block hash.
+                */
                 std::string start() const { return m_start; }
 
                 /**
-                 * End block hash. May be zero.
-                 */
+                * End block hash. May be zero.
+                */
                 std::string end() const { return m_end; }
                 extended_parameters_t* extended() const { return m_extended; }
                 nano_t* _root() const { return m__root; }
@@ -445,8 +468,8 @@ namespace nano {
             };
 
             /**
-             * A peer entry in the keepalive message
-             */
+            * A peer entry in the keepalive message
+            */
 
             class peer_t : public kaitai::kstruct {
 
@@ -456,6 +479,7 @@ namespace nano {
 
             private:
                 void _read();
+                void _clean_up();
 
             public:
                 ~peer_t();
@@ -469,43 +493,50 @@ namespace nano {
             public:
 
                 /**
-                 * ipv6 address, or ipv6-mapped ipv4 address.
-                 */
+                * ipv6 address, or ipv6-mapped ipv4 address.
+                */
                 std::string address() const { return m_address; }
 
                 /**
-                 * Port number. Default port is 7075.
-                 */
+                * Port number. Default port is 7075.
+                */
                 uint16_t port() const { return m_port; }
                 nano_t* _root() const { return m__root; }
                 nano_t::msg_keepalive_t* _parent() const { return m__parent; }
             };
 
             /**
-             * Deprecated. The server will respond with a single enum_blocktype::not_a_block byte.
-             */
+            * Ascending pull sub-header, data common in asc pull packets.
+            */
 
-            class msg_bulk_pull_blocks_t : public kaitai::kstruct {
+            class asc_pull_base_t : public kaitai::kstruct {
 
             public:
 
-                msg_bulk_pull_blocks_t(kaitai::kstream* p__io, nano_t* p__parent = 0, nano_t* p__root = 0);
+                asc_pull_base_t(kaitai::kstream* p__io, kaitai::kstruct* p__parent = 0, nano_t* p__root = 0);
 
             private:
                 void _read();
+                void _clean_up();
 
             public:
-                ~msg_bulk_pull_blocks_t();
+                ~asc_pull_base_t();
 
             private:
-                uint8_t m_block_type;
+                enum_asc_pull_type_t m_type;
+                uint64_t m_id;
                 nano_t* m__root;
-                nano_t* m__parent;
+                kaitai::kstruct* m__parent;
 
             public:
-                uint8_t block_type() const { return m_block_type; }
+                enum_asc_pull_type_t type() const { return m_type; }
+
+                /**
+                * An identifier to associate replies with requests
+                */
+                uint64_t id() const { return m_id; }
                 nano_t* _root() const { return m__root; }
-                nano_t* _parent() const { return m__parent; }
+                kaitai::kstruct* _parent() const { return m__parent; }
             };
 
             class block_open_t : public kaitai::kstruct {
@@ -516,6 +547,7 @@ namespace nano {
 
             private:
                 void _read();
+                void _clean_up();
 
             public:
                 ~block_open_t();
@@ -532,28 +564,28 @@ namespace nano {
             public:
 
                 /**
-                 * Hash of the source send block
-                 */
+                * Hash of the source send block
+                */
                 std::string source() const { return m_source; }
 
                 /**
-                 * Public key of initial representative account
-                 */
+                * Public key of initial representative account
+                */
                 std::string representative() const { return m_representative; }
 
                 /**
-                 * Public key of account being opened
-                 */
+                * Public key of account being opened
+                */
                 std::string account() const { return m_account; }
 
                 /**
-                 * ed25519-blake2b signature
-                 */
+                * ed25519-blake2b signature
+                */
                 std::string signature() const { return m_signature; }
 
                 /**
-                 * Proof of work
-                 */
+                * Proof of work
+                */
                 uint64_t work() const { return m_work; }
                 nano_t* _root() const { return m__root; }
                 nano_t::block_selector_t* _parent() const { return m__parent; }
@@ -567,6 +599,7 @@ namespace nano {
 
             private:
                 void _read();
+                void _clean_up();
 
             public:
                 ~ignore_until_eof_t();
@@ -589,8 +622,8 @@ namespace nano {
             };
 
             /**
-             * Signed confirmation of a block or a list of block hashes
-             */
+            * Signed confirmation of a list of block hashes
+            */
 
             class msg_confirm_ack_t : public kaitai::kstruct {
 
@@ -600,6 +633,7 @@ namespace nano {
 
             private:
                 void _read();
+                void _clean_up();
 
             public:
                 ~msg_confirm_ack_t();
@@ -607,33 +641,19 @@ namespace nano {
             private:
                 vote_common_t* m_common;
                 vote_by_hash_t* m_votebyhash;
-                bool n_votebyhash;
-
-            public:
-                bool _is_null_votebyhash() { votebyhash(); return n_votebyhash; };
-
-            private:
-                block_selector_t* m_block;
-                bool n_block;
-
-            public:
-                bool _is_null_block() { block(); return n_block; };
-
-            private:
                 nano_t* m__root;
                 nano_t* m__parent;
 
             public:
                 vote_common_t* common() const { return m_common; }
                 vote_by_hash_t* votebyhash() const { return m_votebyhash; }
-                block_selector_t* block() const { return m_block; }
                 nano_t* _root() const { return m__root; }
                 nano_t* _parent() const { return m__parent; }
             };
 
             /**
-             * A node ID handshake request and/or response.
-             */
+            * A node ID handshake request and/or response.
+            */
 
             class msg_node_id_handshake_t : public kaitai::kstruct {
 
@@ -643,6 +663,7 @@ namespace nano {
 
             private:
                 void _read();
+                void _clean_up();
 
             public:
                 ~msg_node_id_handshake_t();
@@ -673,8 +694,8 @@ namespace nano {
             };
 
             /**
-             * Request frontiers (account chain head blocks) from a remote node
-             */
+            * Request frontiers (account chain head blocks) from a remote node
+            */
 
             class msg_frontier_req_t : public kaitai::kstruct {
 
@@ -684,6 +705,7 @@ namespace nano {
 
             private:
                 void _read();
+                void _clean_up();
 
             public:
                 ~msg_frontier_req_t();
@@ -698,29 +720,29 @@ namespace nano {
             public:
 
                 /**
-                 * Public key of start account
-                 */
+                * Public key of start account
+                */
                 std::string start() const { return m_start; }
 
                 /**
-                 * Maximum age of included account. If 0xffffffff, turn off age filtering.
-                 */
+                * Maximum age of included account. If 0xffffffff, turn off age filtering.
+                */
                 uint32_t age() const { return m_age; }
 
                 /**
-                 * Maximum number of accounts to include. If 0xffffffff, turn off count limiting.
-                 */
+                * Maximum number of accounts to include. If 0xffffffff, turn off count limiting.
+                */
                 uint32_t count() const { return m_count; }
                 nano_t* _root() const { return m__root; }
                 nano_t* _parent() const { return m__parent; }
             };
 
             /**
-             * A bulk push is equivalent to an unsolicited bulk pull response.
-             * If a node knows about an account a peer doesn't, the node sends
-             * its local blocks for that account to the peer. The stream of
-             * blocks ends with a sentinel block of type enum_blocktype::not_a_block.
-             */
+            * A bulk push is equivalent to an unsolicited bulk pull response.
+            * If a node knows about an account a peer doesn't, the node sends
+            * its local blocks for that account to the peer. The stream of
+            * blocks ends with a sentinel block of type enum_blocktype::not_a_block.
+            */
 
             class msg_bulk_push_t : public kaitai::kstruct {
 
@@ -731,6 +753,7 @@ namespace nano {
 
             private:
                 void _read();
+                void _clean_up();
 
             public:
                 ~msg_bulk_push_t();
@@ -743,6 +766,7 @@ namespace nano {
 
                 private:
                     void _read();
+                    void _clean_up();
 
                 public:
                     ~bulk_push_entry_t();
@@ -779,6 +803,7 @@ namespace nano {
 
             private:
                 void _read();
+                void _clean_up();
 
             public:
                 ~node_id_response_t();
@@ -792,21 +817,217 @@ namespace nano {
             public:
 
                 /**
-                 * Account (node id)
-                 */
+                * Account (node id)
+                */
                 std::string account() const { return m_account; }
 
                 /**
-                 * Signature
-                 */
+                * Signature
+                */
                 std::string signature() const { return m_signature; }
                 nano_t* _root() const { return m__root; }
                 nano_t::msg_node_id_handshake_t* _parent() const { return m__parent; }
             };
 
             /**
-             * The msg_bulk_push request does not have a response.
-             */
+            * ascending pull response
+            */
+
+            class msg_asc_pull_ack_t : public kaitai::kstruct {
+
+            public:
+                class account_info_ack_payload_t;
+                class blocks_ack_payload_t;
+                class asc_pull_ack_payload_t;
+
+                msg_asc_pull_ack_t(kaitai::kstream* p__io, nano_t* p__parent = 0, nano_t* p__root = 0);
+
+            private:
+                void _read();
+                void _clean_up();
+
+            public:
+                ~msg_asc_pull_ack_t();
+
+                /**
+                * ascend pull response account info payload
+                */
+
+                class account_info_ack_payload_t : public kaitai::kstruct {
+
+                public:
+
+                    account_info_ack_payload_t(kaitai::kstream* p__io, nano_t::msg_asc_pull_ack_t::asc_pull_ack_payload_t* p__parent = 0, nano_t* p__root = 0);
+
+                private:
+                    void _read();
+                    void _clean_up();
+
+                public:
+                    ~account_info_ack_payload_t();
+
+                private:
+                    std::string m_account;
+                    std::string m_account_open;
+                    std::string m_account_head;
+                    uint64_t m_block_count;
+                    std::string m_conf_frontier;
+                    uint64_t m_conf_height;
+                    nano_t* m__root;
+                    nano_t::msg_asc_pull_ack_t::asc_pull_ack_payload_t* m__parent;
+
+                public:
+
+                    /**
+                    * account being pulled
+                    */
+                    std::string account() const { return m_account; }
+
+                    /**
+                    * opening block of account
+                    */
+                    std::string account_open() const { return m_account_open; }
+
+                    /**
+                    * block with highest height (can be confirmed or unconfirmed)
+                    */
+                    std::string account_head() const { return m_account_head; }
+
+                    /**
+                    * number of blocks in account (counts confirmed and unconfirmed blocks)
+                    */
+                    uint64_t block_count() const { return m_block_count; }
+
+                    /**
+                    * block hash of confirmation frontier, confirmed block with highest height
+                    */
+                    std::string conf_frontier() const { return m_conf_frontier; }
+
+                    /**
+                    * Height of highest confirmed block
+                    */
+                    uint64_t conf_height() const { return m_conf_height; }
+                    nano_t* _root() const { return m__root; }
+                    nano_t::msg_asc_pull_ack_t::asc_pull_ack_payload_t* _parent() const { return m__parent; }
+                };
+
+                /**
+                * ascend pull response block payload
+                */
+
+                class blocks_ack_payload_t : public kaitai::kstruct {
+
+                public:
+                    class asc_pull_entry_t;
+
+                    blocks_ack_payload_t(kaitai::kstream* p__io, nano_t::msg_asc_pull_ack_t::asc_pull_ack_payload_t* p__parent = 0, nano_t* p__root = 0);
+
+                private:
+                    void _read();
+                    void _clean_up();
+
+                public:
+                    ~blocks_ack_payload_t();
+
+                    class asc_pull_entry_t : public kaitai::kstruct {
+
+                    public:
+
+                        asc_pull_entry_t(kaitai::kstream* p__io, nano_t::msg_asc_pull_ack_t::blocks_ack_payload_t* p__parent = 0, nano_t* p__root = 0);
+
+                    private:
+                        void _read();
+                        void _clean_up();
+
+                    public:
+                        ~asc_pull_entry_t();
+
+                    private:
+                        uint8_t m_block_type;
+                        block_selector_t* m_block;
+                        nano_t* m__root;
+                        nano_t::msg_asc_pull_ack_t::blocks_ack_payload_t* m__parent;
+
+                    public:
+                        uint8_t block_type() const { return m_block_type; }
+                        block_selector_t* block() const { return m_block; }
+                        nano_t* _root() const { return m__root; }
+                        nano_t::msg_asc_pull_ack_t::blocks_ack_payload_t* _parent() const { return m__parent; }
+                    };
+
+                private:
+                    std::vector<asc_pull_entry_t*>* m_entry;
+                    nano_t* m__root;
+                    nano_t::msg_asc_pull_ack_t::asc_pull_ack_payload_t* m__parent;
+
+                public:
+                    std::vector<asc_pull_entry_t*>* entry() const { return m_entry; }
+                    nano_t* _root() const { return m__root; }
+                    nano_t::msg_asc_pull_ack_t::asc_pull_ack_payload_t* _parent() const { return m__parent; }
+                };
+
+                /**
+                * payload of ascend pull responses
+                */
+
+                class asc_pull_ack_payload_t : public kaitai::kstruct {
+
+                public:
+
+                    asc_pull_ack_payload_t(kaitai::kstream* p__io, nano_t::msg_asc_pull_ack_t* p__parent = 0, nano_t* p__root = 0);
+
+                private:
+                    void _read();
+                    void _clean_up();
+
+                public:
+                    ~asc_pull_ack_payload_t();
+
+                private:
+                    account_info_ack_payload_t* m_account_info;
+                    bool n_account_info;
+
+                public:
+                    bool _is_null_account_info() { account_info(); return n_account_info; };
+
+                private:
+                    blocks_ack_payload_t* m_blocks;
+                    bool n_blocks;
+
+                public:
+                    bool _is_null_blocks() { blocks(); return n_blocks; };
+
+                private:
+                    nano_t* m__root;
+                    nano_t::msg_asc_pull_ack_t* m__parent;
+
+                public:
+                    account_info_ack_payload_t* account_info() const { return m_account_info; }
+                    blocks_ack_payload_t* blocks() const { return m_blocks; }
+                    nano_t* _root() const { return m__root; }
+                    nano_t::msg_asc_pull_ack_t* _parent() const { return m__parent; }
+                };
+
+            private:
+                asc_pull_base_t* m_base;
+                asc_pull_ack_payload_t* m_payload;
+                nano_t* m__root;
+                nano_t* m__parent;
+                std::string m__raw_payload;
+                kaitai::kstream* m__io__raw_payload;
+
+            public:
+                asc_pull_base_t* base() const { return m_base; }
+                asc_pull_ack_payload_t* payload() const { return m_payload; }
+                nano_t* _root() const { return m__root; }
+                nano_t* _parent() const { return m__parent; }
+                std::string _raw_payload() const { return m__raw_payload; }
+                kaitai::kstream* _io__raw_payload() const { return m__io__raw_payload; }
+            };
+
+            /**
+            * The msg_bulk_push request does not have a response.
+            */
 
             class bulk_push_response_t : public kaitai::kstruct {
 
@@ -816,6 +1037,7 @@ namespace nano {
 
             private:
                 void _read();
+                void _clean_up();
 
             public:
                 ~bulk_push_response_t();
@@ -830,8 +1052,8 @@ namespace nano {
             };
 
             /**
-             * Response of the msg_bulk_pull request.
-             */
+            * Response of the msg_bulk_pull request.
+            */
 
             class bulk_pull_response_t : public kaitai::kstruct {
 
@@ -842,6 +1064,7 @@ namespace nano {
 
             private:
                 void _read();
+                void _clean_up();
 
             public:
                 ~bulk_pull_response_t();
@@ -854,6 +1077,7 @@ namespace nano {
 
                 private:
                     void _read();
+                    void _clean_up();
 
                 public:
                     ~bulk_pull_entry_t();
@@ -883,8 +1107,8 @@ namespace nano {
             };
 
             /**
-             * Publish the given block
-             */
+            * Publish the given block
+            */
 
             class msg_publish_t : public kaitai::kstruct {
 
@@ -894,6 +1118,7 @@ namespace nano {
 
             private:
                 void _read();
+                void _clean_up();
 
             public:
                 ~msg_publish_t();
@@ -910,8 +1135,8 @@ namespace nano {
             };
 
             /**
-             * State block
-             */
+            * State block
+            */
 
             class block_state_t : public kaitai::kstruct {
 
@@ -921,6 +1146,7 @@ namespace nano {
 
             private:
                 void _read();
+                void _clean_up();
 
             public:
                 ~block_state_t();
@@ -939,46 +1165,46 @@ namespace nano {
             public:
 
                 /**
-                 * Public key of account represented by this state block
-                 */
+                * Public key of account represented by this state block
+                */
                 std::string account() const { return m_account; }
 
                 /**
-                 * Hash of previous block
-                 */
+                * Hash of previous block
+                */
                 std::string previous() const { return m_previous; }
 
                 /**
-                 * Public key of the representative account
-                 */
+                * Public key of the representative account
+                */
                 std::string representative() const { return m_representative; }
 
                 /**
-                 * 128-bit big endian balance
-                 */
+                * 128-bit big endian balance
+                */
                 std::string balance() const { return m_balance; }
 
                 /**
-                 * Pairing send's block hash (open/receive), 0 (change) or destination public key (send)
-                 */
+                * Pairing send's block hash (open/receive), 0 (change) or destination public key (send)
+                */
                 std::string link() const { return m_link; }
 
                 /**
-                 * ed25519-blake2b signature
-                 */
+                * ed25519-blake2b signature
+                */
                 std::string signature() const { return m_signature; }
 
                 /**
-                 * Proof of work (big endian)
-                 */
+                * Proof of work (big endian)
+                */
                 uint64_t work() const { return m_work; }
                 nano_t* _root() const { return m__root; }
                 nano_t::block_selector_t* _parent() const { return m__parent; }
             };
 
             /**
-             * A general purpose pair of 32-byte hash values
-             */
+            * A general purpose pair of 32-byte hash values
+            */
 
             class hash_pair_t : public kaitai::kstruct {
 
@@ -988,6 +1214,7 @@ namespace nano {
 
             private:
                 void _read();
+                void _clean_up();
 
             public:
                 ~hash_pair_t();
@@ -1001,22 +1228,22 @@ namespace nano {
             public:
 
                 /**
-                 * First hash in pair
-                 */
+                * First hash in pair
+                */
                 std::string first() const { return m_first; }
 
                 /**
-                 * Second hash in pair
-                 */
+                * Second hash in pair
+                */
                 std::string second() const { return m_second; }
                 nano_t* _root() const { return m__root; }
                 nano_t::confirm_request_by_hash_t* _parent() const { return m__parent; }
             };
 
             /**
-             * Response of the msg_bulk_pull_account message. The structure depends on the
-             * flags that was passed to the query.
-             */
+            * Response of the msg_bulk_pull_account message. The structure depends on the
+            * flags that was passed to the query.
+            */
 
             class bulk_pull_account_response_t : public kaitai::kstruct {
 
@@ -1028,6 +1255,7 @@ namespace nano {
 
             private:
                 void _read();
+                void _clean_up();
 
             public:
                 ~bulk_pull_account_response_t();
@@ -1040,6 +1268,7 @@ namespace nano {
 
                 private:
                     void _read();
+                    void _clean_up();
 
                 public:
                     ~frontier_balance_entry_t();
@@ -1053,13 +1282,13 @@ namespace nano {
                 public:
 
                     /**
-                     * Hash of the head block of the account chain.
-                     */
+                    * Hash of the head block of the account chain.
+                    */
                     std::string frontier_hash() const { return m_frontier_hash; }
 
                     /**
-                     * 128-bit big endian account balance.
-                     */
+                    * 128-bit big endian account balance.
+                    */
                     std::string balance() const { return m_balance; }
                     nano_t* _root() const { return m__root; }
                     kaitai::kstruct* _parent() const { return m__parent; }
@@ -1073,6 +1302,7 @@ namespace nano {
 
                 private:
                     void _read();
+                    void _clean_up();
 
                 public:
                     ~bulk_pull_account_entry_t();
@@ -1142,8 +1372,8 @@ namespace nano {
             };
 
             /**
-             * A list of 8 peers, some of which may be all-zero.
-             */
+            * A list of 8 peers, some of which may be all-zero.
+            */
 
             class msg_keepalive_t : public kaitai::kstruct {
 
@@ -1153,6 +1383,7 @@ namespace nano {
 
             private:
                 void _read();
+                void _clean_up();
 
             public:
                 ~msg_keepalive_t();
@@ -1175,8 +1406,8 @@ namespace nano {
             };
 
             /**
-             * Requests confirmation of the given block or list of root/hash pairs
-             */
+            * Requests confirmation of the given block or list of root/hash pairs
+            */
 
             class msg_confirm_req_t : public kaitai::kstruct {
 
@@ -1186,6 +1417,7 @@ namespace nano {
 
             private:
                 void _read();
+                void _clean_up();
 
             public:
                 ~msg_confirm_req_t();
@@ -1216,8 +1448,8 @@ namespace nano {
             };
 
             /**
-             * Bulk pull account request.
-             */
+            * Bulk pull account request.
+            */
 
             class msg_bulk_pull_account_t : public kaitai::kstruct {
 
@@ -1227,6 +1459,7 @@ namespace nano {
 
             private:
                 void _read();
+                void _clean_up();
 
             public:
                 ~msg_bulk_pull_account_t();
@@ -1241,13 +1474,13 @@ namespace nano {
             public:
 
                 /**
-                 * Account public key.
-                 */
+                * Account public key.
+                */
                 std::string account() const { return m_account; }
 
                 /**
-                 * 128-bit big endian minimum amount.
-                 */
+                * 128-bit big endian minimum amount.
+                */
                 std::string minimum_amount() const { return m_minimum_amount; }
                 enum_bulk_pull_account_t flags() const { return m_flags; }
                 nano_t* _root() const { return m__root; }
@@ -1255,8 +1488,8 @@ namespace nano {
             };
 
             /**
-             * A sequence of hashes, where count is read from header.
-             */
+            * A sequence of hashes, where count is read from header.
+            */
 
             class vote_by_hash_t : public kaitai::kstruct {
 
@@ -1266,6 +1499,7 @@ namespace nano {
 
             private:
                 void _read();
+                void _clean_up();
 
             public:
                 ~vote_by_hash_t();
@@ -1288,8 +1522,8 @@ namespace nano {
             };
 
             /**
-             * Common data shared by block votes and vote-by-hash votes
-             */
+            * Common data shared by votes
+            */
 
             class vote_common_t : public kaitai::kstruct {
 
@@ -1299,21 +1533,44 @@ namespace nano {
 
             private:
                 void _read();
+                void _clean_up();
 
             public:
                 ~vote_common_t();
 
             private:
+                bool f_timestamp;
+                int32_t m_timestamp;
+
+            public:
+
+                /**
+                * Number of seconds since the UTC epoch vote was generated at
+                */
+                int32_t timestamp();
+
+            private:
+                bool f_vote_duration_bits;
+                int32_t m_vote_duration_bits;
+
+            public:
+
+                /**
+                * Since V23.0 this is specified as 2^(duration + 4) in milliseconds
+                */
+                int32_t vote_duration_bits();
+
+            private:
                 std::string m_account;
                 std::string m_signature;
-                uint64_t m_sequence;
+                uint64_t m_timestamp_and_vote_duration;
                 nano_t* m__root;
                 nano_t::msg_confirm_ack_t* m__parent;
 
             public:
                 std::string account() const { return m_account; }
                 std::string signature() const { return m_signature; }
-                uint64_t sequence() const { return m_sequence; }
+                uint64_t timestamp_and_vote_duration() const { return m_timestamp_and_vote_duration; }
                 nano_t* _root() const { return m__root; }
                 nano_t::msg_confirm_ack_t* _parent() const { return m__parent; }
             };
@@ -1326,9 +1583,23 @@ namespace nano {
 
             private:
                 void _read();
+                void _clean_up();
 
             public:
                 ~message_header_t();
+
+            private:
+                bool f_bulk_pull_ascending_flag;
+                int32_t m_bulk_pull_ascending_flag;
+
+            public:
+
+                /**
+                * Since protocol version 19 (release 24).
+                * May be set for "bulk_pull" messages.
+                * If set, it reverses the order in which bulk_pull returns blocks. It returns the frontier block last.
+                */
+                int32_t bulk_pull_ascending_flag();
 
             private:
                 bool f_response_flag;
@@ -1337,9 +1608,9 @@ namespace nano {
             public:
 
                 /**
-                 * If set, this is a node_id_handshake response. This maybe be set at the
-                 * same time as the query_flag.
-                 */
+                * If set, this is a node_id_handshake response. This maybe be set at the
+                * same time as the query_flag.
+                */
                 int32_t response_flag();
 
             private:
@@ -1356,9 +1627,9 @@ namespace nano {
             public:
 
                 /**
-                 * Since protocol version 18.
-                 * Must be set for "telemetry_ack" messages. Indicates size of payload.
-                 */
+                * Since protocol version 18.
+                * Must be set for "telemetry_ack" messages. Indicates size of payload.
+                */
                 int32_t telemetry_size();
 
             private:
@@ -1368,10 +1639,10 @@ namespace nano {
             public:
 
                 /**
-                 * Since protocol version 15.
-                 * May be set for "bulk_pull" messages.
-                 * If set, the bulk_pull message contain extended parameters.
-                 */
+                * Since protocol version 15.
+                * May be set for "bulk_pull" messages.
+                * If set, the bulk_pull message contain extended parameters.
+                */
                 int32_t extended_params_present();
 
             private:
@@ -1381,10 +1652,10 @@ namespace nano {
             public:
 
                 /**
-                 * The block type determines what block is embedded in the message.
-                 * For some message types, block type is not relevant and the block type
-                 * is set to "invalid" or "not_a_block"
-                 */
+                * The block type determines what block is embedded in the message.
+                * For some message types, block type is not relevant and the block type
+                * is set to "invalid" or "not_a_block"
+                */
                 enum_blocktype_t block_type();
 
             private:
@@ -1394,9 +1665,9 @@ namespace nano {
             public:
 
                 /**
-                 * Since protocol v17. For confirm_ack vote-by-hash, this is the number of hashes
-                 * in the body. For confirm_req request-by-hash, this is the number of hash+root pairs.
-                 */
+                * Since protocol v17. For confirm_ack vote-by-hash, this is the number of hashes
+                * in the body. For confirm_req request-by-hash, this is the number of hash+root pairs.
+                */
                 int32_t item_count_int();
 
             private:
@@ -1406,10 +1677,35 @@ namespace nano {
             public:
 
                 /**
-                 * If set, this is a node_id_handshake query. This maybe be set at the
-                 * same time as the response_flag.
-                 */
+                * If set, this is a node_id_handshake query. This maybe be set at the
+                * same time as the response_flag.
+                */
                 int32_t query_flag();
+
+            private:
+                bool f_confirmed_present;
+                int32_t m_confirmed_present;
+
+            public:
+
+                /**
+                * Since protocol version 18 (release 21.3).
+                * May be set for "frontier_req" messages.
+                * If set, the frontier_req response contains confirmed frontiers for each account.
+                */
+                int32_t confirmed_present();
+
+            private:
+                bool f_asc_pull_size;
+                int32_t m_asc_pull_size;
+
+            public:
+
+                /**
+                * Since protocol version 19 (release 24)
+                * Must be set for "ascending pull messages" messages. Indicates size of payload of ascending pull message.
+                */
+                int32_t asc_pull_size();
 
             private:
                 std::string m_magic;
@@ -1425,46 +1721,46 @@ namespace nano {
             public:
 
                 /**
-                 * Protocol identifier. Always 'R'.
-                 */
+                * Protocol identifier. Always 'R'.
+                */
                 std::string magic() const { return m_magic; }
 
                 /**
-                 * Network ID 'A', 'B' or 'C' for test, beta or live network respectively.
-                 */
+                * Network ID 'A', 'B' or 'C' for test, beta or live network respectively.
+                */
                 enum_network_t network_id() const { return m_network_id; }
 
                 /**
-                 * Maximum version supported by the sending node
-                 */
+                * Maximum version supported by the sending node
+                */
                 uint8_t version_max() const { return m_version_max; }
 
                 /**
-                 * Version used by the sending node
-                 */
+                * Version used by the sending node
+                */
                 uint8_t version_using() const { return m_version_using; }
 
                 /**
-                 * Minimum version supported by the sending node
-                 */
+                * Minimum version supported by the sending node
+                */
                 uint8_t version_min() const { return m_version_min; }
 
                 /**
-                 * Message type
-                 */
+                * Message type
+                */
                 enum_msgtype_t message_type() const { return m_message_type; }
 
                 /**
-                 * Extensions bitfield
-                 */
+                * Extensions bitfield
+                */
                 uint16_t extensions() const { return m_extensions; }
                 nano_t* _root() const { return m__root; }
                 nano_t* _parent() const { return m__parent; }
             };
 
             /**
-             * Response of the msg_frontier_req TCP request. An all-zero account and frontier_hash signifies the end of the result.
-             */
+            * Response of the msg_frontier_req TCP request. An all-zero account and frontier_hash signifies the end of the result.
+            */
 
             class frontier_response_t : public kaitai::kstruct {
 
@@ -1475,6 +1771,7 @@ namespace nano {
 
             private:
                 void _read();
+                void _clean_up();
 
             public:
                 ~frontier_response_t();
@@ -1487,6 +1784,7 @@ namespace nano {
 
                 private:
                     void _read();
+                    void _clean_up();
 
                 public:
                     ~frontier_entry_t();
@@ -1500,13 +1798,13 @@ namespace nano {
                 public:
 
                     /**
-                     * Public key of account.
-                     */
+                    * Public key of account.
+                    */
                     std::string account() const { return m_account; }
 
                     /**
-                     * Hash of the head block of the account chain.
-                     */
+                    * Hash of the head block of the account chain.
+                    */
                     std::string frontier_hash() const { return m_frontier_hash; }
                     nano_t* _root() const { return m__root; }
                     kaitai::kstruct* _parent() const { return m__parent; }
@@ -1524,8 +1822,161 @@ namespace nano {
             };
 
             /**
-             * Signed telemetry response
-             */
+            * ascending pull request
+            */
+
+            class msg_asc_pull_req_t : public kaitai::kstruct {
+
+            public:
+                class account_info_req_payload_t;
+                class blocks_req_payload_t;
+                class asc_pull_req_payload_t;
+
+                msg_asc_pull_req_t(kaitai::kstream* p__io, nano_t* p__parent = 0, nano_t* p__root = 0);
+
+            private:
+                void _read();
+                void _clean_up();
+
+            public:
+                ~msg_asc_pull_req_t();
+
+                /**
+                * ascend pull request acount info payload
+                */
+
+                class account_info_req_payload_t : public kaitai::kstruct {
+
+                public:
+
+                    account_info_req_payload_t(kaitai::kstream* p__io, nano_t::msg_asc_pull_req_t::asc_pull_req_payload_t* p__parent = 0, nano_t* p__root = 0);
+
+                private:
+                    void _read();
+                    void _clean_up();
+
+                public:
+                    ~account_info_req_payload_t();
+
+                private:
+                    std::string m_start;
+                    enum_asc_hash_type_t m_start_type;
+                    nano_t* m__root;
+                    nano_t::msg_asc_pull_req_t::asc_pull_req_payload_t* m__parent;
+
+                public:
+
+                    /**
+                    * block hash or account pubkey to pull from
+                    */
+                    std::string start() const { return m_start; }
+                    enum_asc_hash_type_t start_type() const { return m_start_type; }
+                    nano_t* _root() const { return m__root; }
+                    nano_t::msg_asc_pull_req_t::asc_pull_req_payload_t* _parent() const { return m__parent; }
+                };
+
+                /**
+                * ascend pull request block payload
+                */
+
+                class blocks_req_payload_t : public kaitai::kstruct {
+
+                public:
+
+                    blocks_req_payload_t(kaitai::kstream* p__io, nano_t::msg_asc_pull_req_t::asc_pull_req_payload_t* p__parent = 0, nano_t* p__root = 0);
+
+                private:
+                    void _read();
+                    void _clean_up();
+
+                public:
+                    ~blocks_req_payload_t();
+
+                private:
+                    std::string m_start;
+                    uint8_t m_count;
+                    enum_asc_hash_type_t m_start_type;
+                    nano_t* m__root;
+                    nano_t::msg_asc_pull_req_t::asc_pull_req_payload_t* m__parent;
+
+                public:
+
+                    /**
+                    * block hash or account pubkey to pull from
+                    */
+                    std::string start() const { return m_start; }
+
+                    /**
+                    * max number of blocks to pull
+                    */
+                    uint8_t count() const { return m_count; }
+                    enum_asc_hash_type_t start_type() const { return m_start_type; }
+                    nano_t* _root() const { return m__root; }
+                    nano_t::msg_asc_pull_req_t::asc_pull_req_payload_t* _parent() const { return m__parent; }
+                };
+
+                /**
+                * payload of ascend pull requests
+                */
+
+                class asc_pull_req_payload_t : public kaitai::kstruct {
+
+                public:
+
+                    asc_pull_req_payload_t(kaitai::kstream* p__io, nano_t::msg_asc_pull_req_t* p__parent = 0, nano_t* p__root = 0);
+
+                private:
+                    void _read();
+                    void _clean_up();
+
+                public:
+                    ~asc_pull_req_payload_t();
+
+                private:
+                    account_info_req_payload_t* m_account_info;
+                    bool n_account_info;
+
+                public:
+                    bool _is_null_account_info() { account_info(); return n_account_info; };
+
+                private:
+                    blocks_req_payload_t* m_blocks;
+                    bool n_blocks;
+
+                public:
+                    bool _is_null_blocks() { blocks(); return n_blocks; };
+
+                private:
+                    nano_t* m__root;
+                    nano_t::msg_asc_pull_req_t* m__parent;
+
+                public:
+                    account_info_req_payload_t* account_info() const { return m_account_info; }
+                    blocks_req_payload_t* blocks() const { return m_blocks; }
+                    nano_t* _root() const { return m__root; }
+                    nano_t::msg_asc_pull_req_t* _parent() const { return m__parent; }
+                };
+
+            private:
+                asc_pull_base_t* m_base;
+                asc_pull_req_payload_t* m_payload;
+                nano_t* m__root;
+                nano_t* m__parent;
+                std::string m__raw_payload;
+                kaitai::kstream* m__io__raw_payload;
+
+            public:
+                asc_pull_base_t* base() const { return m_base; }
+                asc_pull_req_payload_t* payload() const { return m_payload; }
+                nano_t* _root() const { return m__root; }
+                nano_t* _parent() const { return m__parent; }
+                std::string _raw_payload() const { return m__raw_payload; }
+                kaitai::kstream* _io__raw_payload() const { return m__io__raw_payload; }
+            };
+
+            /**
+            * Signed telemetry response
+            */
 
             class msg_telemetry_ack_t : public kaitai::kstruct {
 
@@ -1535,6 +1986,7 @@ namespace nano {
 
             private:
                 void _read();
+                void _clean_up();
 
             public:
                 ~msg_telemetry_ack_t();
@@ -1547,9 +1999,9 @@ namespace nano {
                 uint64_t m_uncheckedcount;
                 uint64_t m_accountcount;
                 uint64_t m_bandwidthcap;
-                uint64_t m_uptime;
                 uint32_t m_peercount;
                 uint8_t m_protocolversion;
+                uint64_t m_uptime;
                 std::string m_genesisblock;
                 uint8_t m_majorversion;
                 uint8_t m_minorversion;
@@ -1558,100 +2010,108 @@ namespace nano {
                 uint8_t m_maker;
                 uint64_t m_timestamp;
                 uint64_t m_activedifficulty;
+                std::vector<uint64_t>* m_unknown_data;
+                bool n_unknown_data;
+
+            public:
+                bool _is_null_unknown_data() { unknown_data(); return n_unknown_data; };
+
+            private:
                 nano_t* m__root;
                 nano_t* m__parent;
 
             public:
 
                 /**
-                 * Signature (Big endian)
-                 */
+                * Signature (Big endian)
+                */
                 std::string signature() const { return m_signature; }
 
                 /**
-                 * Public node id (Big endian)
-                 */
+                * Public node id (Big endian)
+                */
                 std::string nodeid() const { return m_nodeid; }
 
                 /**
-                 * Block count
-                 */
+                * Block count
+                */
                 uint64_t blockcount() const { return m_blockcount; }
 
                 /**
-                 * Cemented block count
-                 */
+                * Cemented block count
+                */
                 uint64_t cementedcount() const { return m_cementedcount; }
 
                 /**
-                 * Unchecked block count
-                 */
+                * Unchecked block count
+                */
                 uint64_t uncheckedcount() const { return m_uncheckedcount; }
 
                 /**
-                 * Account count
-                 */
+                * Account count
+                */
                 uint64_t accountcount() const { return m_accountcount; }
 
                 /**
-                 * Bandwidth limit, 0 indiciates unlimited
-                 */
+                * Bandwidth limit, 0 indiciates unlimited
+                */
                 uint64_t bandwidthcap() const { return m_bandwidthcap; }
 
                 /**
-                 * Length of time a peer has been running for (in seconds)
-                 */
-                uint64_t uptime() const { return m_uptime; }
-
-                /**
-                 * Peer count
-                 */
+                * Peer count
+                */
                 uint32_t peercount() const { return m_peercount; }
 
                 /**
-                 * Protocol version
-                 */
+                * Protocol version
+                */
                 uint8_t protocolversion() const { return m_protocolversion; }
 
                 /**
-                 * Genesis block hash (Big endian)
-                 */
+                * Length of time a peer has been running for (in seconds)
+                */
+                uint64_t uptime() const { return m_uptime; }
+
+                /**
+                * Genesis block hash (Big endian)
+                */
                 std::string genesisblock() const { return m_genesisblock; }
 
                 /**
-                 * Major version
-                 */
+                * Major version
+                */
                 uint8_t majorversion() const { return m_majorversion; }
 
                 /**
-                 * Minor version
-                 */
+                * Minor version
+                */
                 uint8_t minorversion() const { return m_minorversion; }
 
                 /**
-                 * Patch version
-                 */
+                * Patch version
+                */
                 uint8_t patchversion() const { return m_patchversion; }
 
                 /**
-                 * Pre-release version
-                 */
+                * Pre-release version
+                */
                 uint8_t prereleaseversion() const { return m_prereleaseversion; }
 
                 /**
-                 * Maker version. 0 indicates it is from the Nano Foundation, there is no standardised list yet for any others.
-                 */
+                * Maker version. 0 indicates it is from the Nano Foundation, there is no standardised list yet for any others.
+                */
                 uint8_t maker() const { return m_maker; }
 
                 /**
-                 * Number of milliseconds since the UTC epoch
-                 */
+                * Number of milliseconds since the UTC epoch
+                */
                 uint64_t timestamp() const { return m_timestamp; }
 
                 /**
-                 * The current network active difficulty.
-                 */
+                * The current network active difficulty.
+                */
                 uint64_t activedifficulty() const { return m_activedifficulty; }
+                std::vector<uint64_t>* unknown_data() const { return m_unknown_data; }
                 nano_t* _root() const { return m__root; }
                 nano_t* _parent() const { return m__parent; }
             };
@@ -1672,13 +2132,13 @@ namespace nano {
         public:
 
             /**
-             * Message header with message type, version information and message-specific extension bits.
-             */
+            * Message header with message type, version information and message-specific extension bits.
+            */
             message_header_t* header() const { return m_header; }
 
             /**
-             * Message body whose content depends on block type in the header.
-             */
+            * Message body whose content depends on block type in the header.
+            */
             kaitai::kstruct* body() const { return m_body; }
             nano_t* _root() const { return m__root; }
             kaitai::kstruct* _parent() const { return m__parent; }

--- a/src/packet_handler.cpp
+++ b/src/packet_handler.cpp
@@ -602,11 +602,23 @@ void nanocap::packet_handler::handle_tcp(nanocap::nano_packet& info)
 					this->handle_message (*msg, info);
 					break;
 				}
-				case nano::protocol::nano_t::ENUM_MSGTYPE_BULK_PULL_BLOCKS:
+				case nano::protocol::nano_t::ENUM_MSGTYPE_ASC_PULL_ACK:
 				{
-					// This message type is no longer used by the node
+					nano::protocol::nano_t::msg_asc_pull_ack_t* msg = static_cast<nano::protocol::nano_t::msg_asc_pull_ack_t*> (proto.body ());
+					this->handle_message (*msg, info);
 					break;
 				}
+				case nano::protocol::nano_t::ENUM_MSGTYPE_ASC_PULL_REQ:
+				{
+					nano::protocol::nano_t::msg_asc_pull_req_t* msg = static_cast<nano::protocol::nano_t::msg_asc_pull_req_t*> (proto.body ());
+					this->handle_message (*msg, info);
+					break;
+				}
+				// case nano::protocol::nano_t::ENUM_MSGTYPE_BULK_PULL_BLOCKS:
+				// {
+				// 	// This message type is no longer used by the node
+				// 	break;
+				// }
 			}
 		}
 	}
@@ -772,6 +784,34 @@ void nanocap::packet_handler::handle_message (nano::protocol::nano_t::msg_bulk_p
 		if (get_app().get_config().capture.connection_details)
 		{
 			get_app().get_db().put_connection(info.ip_version, info.src_ip, info.src_port, info.dst_ip, info.dst_port, info.flow_key, "bulk_pull_account");
+		}
+	}
+
+	app.get_db().put(msg, info);
+}
+
+void nanocap::packet_handler::handle_message (nano::protocol::nano_t::msg_asc_pull_ack_t & msg, nanocap::nano_packet& info)
+{
+	if (info.flow_data)
+	{
+		info.flow_data->reset(nano::protocol::nano_t::enum_msgtype_t::ENUM_MSGTYPE_ASC_PULL_ACK);
+		if (get_app().get_config().capture.connection_details)
+		{
+			get_app().get_db().put_connection(info.ip_version, info.src_ip, info.src_port, info.dst_ip, info.dst_port, info.flow_key, "asc_pull_ack");
+		}
+	}
+
+	app.get_db().put(msg, info);
+}
+
+void nanocap::packet_handler::handle_message (nano::protocol::nano_t::msg_asc_pull_req_t & msg, nanocap::nano_packet& info)
+{
+	if (info.flow_data)
+	{
+		info.flow_data->reset(nano::protocol::nano_t::enum_msgtype_t::ENUM_MSGTYPE_ASC_PULL_REQ);
+		if (get_app().get_config().capture.connection_details)
+		{
+			get_app().get_db().put_connection(info.ip_version, info.src_ip, info.src_port, info.dst_ip, info.dst_port, info.flow_key, "asc_pull_req");
 		}
 	}
 

--- a/src/packet_handler.hpp
+++ b/src/packet_handler.hpp
@@ -104,6 +104,9 @@ namespace nanocap
 		void handle_message (nano::protocol::nano_t::msg_bulk_pull_t & msg, nano_packet& info);
 		void handle_message (nano::protocol::nano_t::msg_bulk_push_t & msg, nano_packet& info);
 		void handle_message (nano::protocol::nano_t::msg_bulk_pull_account_t & msg, nano_packet& info);
+		void handle_message (nano::protocol::nano_t::msg_asc_pull_ack_t & msg, nano_packet& info);
+		void handle_message (nano::protocol::nano_t::msg_asc_pull_req_t & msg, nano_packet& info);
+
 
 		pcpp::PcapLiveDevice* get_device() { return dev; }
 		nanocap::app& get_app() const { return app; }

--- a/src/webserver/client_http.hpp
+++ b/src/webserver/client_http.hpp
@@ -119,7 +119,7 @@ namespace SimpleWeb {
           timer = nullptr;
           return;
         }
-        timer = std::unique_ptr<asio::steady_timer>(new asio::steady_timer(socket->get_io_service()));
+        timer = std::unique_ptr<asio::steady_timer>(new asio::steady_timer(static_cast<asio::io_context&>(socket->get_executor().context())));
         timer->expires_from_now(std::chrono::seconds(seconds));
         auto self = this->shared_from_this();
         timer->async_wait([self](const error_code &ec) {

--- a/src/webserver/server_http.hpp
+++ b/src/webserver/server_http.hpp
@@ -66,7 +66,7 @@ namespace SimpleWeb {
       asio::io_service::strand strand;
       std::list<std::pair<std::shared_ptr<asio::streambuf>, std::function<void(const error_code &)>>> send_queue;
 
-      Response(std::shared_ptr<Session> session_, long timeout_content) noexcept : std::ostream(nullptr), session(std::move(session_)), timeout_content(timeout_content), strand(session->connection->socket->get_io_service()) {
+      Response(std::shared_ptr<Session> session_, long timeout_content) noexcept : std::ostream(nullptr), session(std::move(session_)), timeout_content(timeout_content), strand(static_cast<boost::asio::io_context&>(session->connection->socket->get_executor().context())) {
         rdbuf(streambuf.get());
       }
 
@@ -296,7 +296,7 @@ namespace SimpleWeb {
           return;
         }
 
-        timer = std::unique_ptr<asio::steady_timer>(new asio::steady_timer(socket->get_io_service()));
+        timer = std::unique_ptr<asio::steady_timer>(new asio::steady_timer(static_cast<asio::io_context&>(socket->get_executor().context())));
         timer->expires_from_now(std::chrono::seconds(seconds));
         auto self = this->shared_from_this();
         timer->async_wait([self](const error_code &ec) {


### PR DESCRIPTION
Create a docker image no longer works as  Conan changes.
- This PR removes the need for Conan  
- Adds basic support for the new protocol messages 
  - msg_asc_pull_ack
  - msg_asc_pull_req

Current issues:
- the docker container sometimes exits without any exception message
- there is a big difference in the pcap statsitics and the number of messages writted to sql

```
-----------Statistics------------
Received by pcap     : 563429
Dropped by pcap      : 128
Dropped by interface : 0
```

vs 21722 packets in sql

msg_type | msg_count
-- | --
0x2 | 42
0x3 | 5720
0x4 | 965
0x5 | 3790
0x6 | 103
0x8 | 39
0xa | 48
0xb | 4
0xe | 4975
0xf | 6036

 